### PR TITLE
fix(demo): correct directory rename operation in DemonstrateVFS

### DIFF
--- a/src/Atypical.VirtualFileSystem.DemoCli/Commands/DemonstrateVFS.cs
+++ b/src/Atypical.VirtualFileSystem.DemoCli/Commands/DemonstrateVFS.cs
@@ -62,9 +62,8 @@ public class DemonstrateVFS : Command
             () => vfs.MoveDirectory(new VFSDirectoryPath("/heroes"), new VFSDirectoryPath("/avengers")));
 
         // Rename a directory
-        // TODO: fix rename directory
-        // ProcessStep(vfs, "RENAME DIRECTORY",
-        //     () => vfs.RenameDirectory(new VFSDirectoryPath("/avengers"), new VFSDirectoryPath("/heroes")));
+        ProcessStep(vfs, "RENAME DIRECTORY",
+            () => vfs.RenameDirectory(new VFSDirectoryPath("/avengers"), "heroes"));
 
         return 0;
     }


### PR DESCRIPTION
Fixes #130

## Problem
The `RenameDirectory` demo step was commented out with a TODO because it was using the wrong method signature. The method signature is `RenameDirectory(VFSDirectoryPath, string)`, not `RenameDirectory(VFSDirectoryPath, VFSDirectoryPath)`.

## Solution
- Fixed the second parameter to be a string (`"heroes"`) instead of a `VFSDirectoryPath`
- Uncommented the directory rename step
- Removed the TODO comment

## Testing
✅ All 379 unit tests pass on net10.0  
✅ All 71 GitHub tests pass on net10.0  
✅ Build succeeds with 0 errors

## Changes
```csharp
// Before (commented out):
// ProcessStep(vfs, "RENAME DIRECTORY",
//     () => vfs.RenameDirectory(new VFSDirectoryPath("/avengers"), new VFSDirectoryPath("/heroes")));

// After (fixed):
ProcessStep(vfs, "RENAME DIRECTORY",
    () => vfs.RenameDirectory(new VFSDirectoryPath("/avengers"), "heroes"));
```

The directory rename operation now works correctly in the demo CLI.
