### PR TITLE
ci: standardize workflows and fix stale SDK versions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,6 +9,14 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
 

--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 9.x
+          dotnet-version: 10.0.x
 
       - name: Cache NuGet packages
         uses: actions/cache@v5
@@ -48,10 +48,10 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 9.x
+          dotnet-version: 10.0.x
 
       - name: Run Test
-        run: dotnet test --configuration $BUILD_CONFIG --no-build --verbosity normal --framework net7.0
+        run: dotnet test --configuration $BUILD_CONFIG --verbosity normal
 
   publish:
     needs: test
@@ -71,7 +71,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 9.x
+          dotnet-version: 10.0.x
 
       - name: Publish to NuGet
         if: startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
## Summary
- Update .NET SDK from 9.x to 10.0.x in publish-to-nuget.yml
- Remove stale `--framework net7.0` flag from test step (use project TFM)
- Add `DOTNET_NOLOGO` and `DOTNET_SKIP_FIRST_TIME_EXPERIENCE` env vars to dotnet.yml
- Add concurrency group to dotnet.yml to cancel redundant runs

## Test plan
- [ ] Verify dotnet.yml workflow runs with new env vars
- [ ] Verify publish-to-nuget.yml builds with .NET 10.0.x SDK
- [ ] Verify tests run without --framework net7.0 restriction