### PR TITLE
feat: storage provider abstraction + FTP provider

### DIFF
--- a/Atypical.VirtualFileSystem.sln
+++ b/Atypical.VirtualFileSystem.sln
@@ -23,6 +23,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atypical.VirtualFileSystem.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atypical.VirtualFileSystem.GitHub.Tests", "tests\Atypical.VirtualFileSystem.GitHub.Tests\Atypical.VirtualFileSystem.GitHub.Tests.csproj", "{31971414-5519-4149-B5C0-C88454EBE7AD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atypical.VirtualFileSystem.Providers.Abstractions", "src\Atypical.VirtualFileSystem.Providers.Abstractions\Atypical.VirtualFileSystem.Providers.Abstractions.csproj", "{B2E9D21C-6C01-4F28-AF7C-2EF16148E964}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -117,6 +119,18 @@ Global
 		{31971414-5519-4149-B5C0-C88454EBE7AD}.Release|x64.Build.0 = Release|Any CPU
 		{31971414-5519-4149-B5C0-C88454EBE7AD}.Release|x86.ActiveCfg = Release|Any CPU
 		{31971414-5519-4149-B5C0-C88454EBE7AD}.Release|x86.Build.0 = Release|Any CPU
+		{B2E9D21C-6C01-4F28-AF7C-2EF16148E964}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2E9D21C-6C01-4F28-AF7C-2EF16148E964}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2E9D21C-6C01-4F28-AF7C-2EF16148E964}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B2E9D21C-6C01-4F28-AF7C-2EF16148E964}.Debug|x64.Build.0 = Debug|Any CPU
+		{B2E9D21C-6C01-4F28-AF7C-2EF16148E964}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B2E9D21C-6C01-4F28-AF7C-2EF16148E964}.Debug|x86.Build.0 = Debug|Any CPU
+		{B2E9D21C-6C01-4F28-AF7C-2EF16148E964}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2E9D21C-6C01-4F28-AF7C-2EF16148E964}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2E9D21C-6C01-4F28-AF7C-2EF16148E964}.Release|x64.ActiveCfg = Release|Any CPU
+		{B2E9D21C-6C01-4F28-AF7C-2EF16148E964}.Release|x64.Build.0 = Release|Any CPU
+		{B2E9D21C-6C01-4F28-AF7C-2EF16148E964}.Release|x86.ActiveCfg = Release|Any CPU
+		{B2E9D21C-6C01-4F28-AF7C-2EF16148E964}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -129,5 +143,6 @@ Global
 		{A1B2C3D4-E5F6-7890-1234-567890ABCDEF} = {10E2E10B-AB65-4800-93ED-CDB737917154}
 		{0F803EA9-AD74-46E3-9404-5D536E0F262C} = {BA11C821-EFDE-4714-A0DE-B7D4D93CE336}
 		{31971414-5519-4149-B5C0-C88454EBE7AD} = {10E2E10B-AB65-4800-93ED-CDB737917154}
+		{B2E9D21C-6C01-4F28-AF7C-2EF16148E964} = {BA11C821-EFDE-4714-A0DE-B7D4D93CE336}
 	EndGlobalSection
 EndGlobal

--- a/Atypical.VirtualFileSystem.sln
+++ b/Atypical.VirtualFileSystem.sln
@@ -27,6 +27,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atypical.VirtualFileSystem.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atypical.VirtualFileSystem.Providers.Abstractions.Tests", "tests\Atypical.VirtualFileSystem.Providers.Abstractions.Tests\Atypical.VirtualFileSystem.Providers.Abstractions.Tests.csproj", "{2E8D3BE3-F419-46B1-BBD3-FC5F753261D0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atypical.VirtualFileSystem.Ftp", "src\Atypical.VirtualFileSystem.Ftp\Atypical.VirtualFileSystem.Ftp.csproj", "{9601A06C-4C43-4E68-8576-F92BBFFEA73B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -145,6 +147,18 @@ Global
 		{2E8D3BE3-F419-46B1-BBD3-FC5F753261D0}.Release|x64.Build.0 = Release|Any CPU
 		{2E8D3BE3-F419-46B1-BBD3-FC5F753261D0}.Release|x86.ActiveCfg = Release|Any CPU
 		{2E8D3BE3-F419-46B1-BBD3-FC5F753261D0}.Release|x86.Build.0 = Release|Any CPU
+		{9601A06C-4C43-4E68-8576-F92BBFFEA73B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9601A06C-4C43-4E68-8576-F92BBFFEA73B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9601A06C-4C43-4E68-8576-F92BBFFEA73B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9601A06C-4C43-4E68-8576-F92BBFFEA73B}.Debug|x64.Build.0 = Debug|Any CPU
+		{9601A06C-4C43-4E68-8576-F92BBFFEA73B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9601A06C-4C43-4E68-8576-F92BBFFEA73B}.Debug|x86.Build.0 = Debug|Any CPU
+		{9601A06C-4C43-4E68-8576-F92BBFFEA73B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9601A06C-4C43-4E68-8576-F92BBFFEA73B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9601A06C-4C43-4E68-8576-F92BBFFEA73B}.Release|x64.ActiveCfg = Release|Any CPU
+		{9601A06C-4C43-4E68-8576-F92BBFFEA73B}.Release|x64.Build.0 = Release|Any CPU
+		{9601A06C-4C43-4E68-8576-F92BBFFEA73B}.Release|x86.ActiveCfg = Release|Any CPU
+		{9601A06C-4C43-4E68-8576-F92BBFFEA73B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -159,5 +173,6 @@ Global
 		{31971414-5519-4149-B5C0-C88454EBE7AD} = {10E2E10B-AB65-4800-93ED-CDB737917154}
 		{B2E9D21C-6C01-4F28-AF7C-2EF16148E964} = {BA11C821-EFDE-4714-A0DE-B7D4D93CE336}
 		{2E8D3BE3-F419-46B1-BBD3-FC5F753261D0} = {10E2E10B-AB65-4800-93ED-CDB737917154}
+		{9601A06C-4C43-4E68-8576-F92BBFFEA73B} = {BA11C821-EFDE-4714-A0DE-B7D4D93CE336}
 	EndGlobalSection
 EndGlobal

--- a/Atypical.VirtualFileSystem.sln
+++ b/Atypical.VirtualFileSystem.sln
@@ -29,6 +29,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atypical.VirtualFileSystem.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atypical.VirtualFileSystem.Ftp", "src\Atypical.VirtualFileSystem.Ftp\Atypical.VirtualFileSystem.Ftp.csproj", "{9601A06C-4C43-4E68-8576-F92BBFFEA73B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atypical.VirtualFileSystem.Ftp.Tests", "tests\Atypical.VirtualFileSystem.Ftp.Tests\Atypical.VirtualFileSystem.Ftp.Tests.csproj", "{37D1D6B7-C4E5-44EC-96C1-C2C6CDB900C5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -159,6 +161,18 @@ Global
 		{9601A06C-4C43-4E68-8576-F92BBFFEA73B}.Release|x64.Build.0 = Release|Any CPU
 		{9601A06C-4C43-4E68-8576-F92BBFFEA73B}.Release|x86.ActiveCfg = Release|Any CPU
 		{9601A06C-4C43-4E68-8576-F92BBFFEA73B}.Release|x86.Build.0 = Release|Any CPU
+		{37D1D6B7-C4E5-44EC-96C1-C2C6CDB900C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{37D1D6B7-C4E5-44EC-96C1-C2C6CDB900C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{37D1D6B7-C4E5-44EC-96C1-C2C6CDB900C5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{37D1D6B7-C4E5-44EC-96C1-C2C6CDB900C5}.Debug|x64.Build.0 = Debug|Any CPU
+		{37D1D6B7-C4E5-44EC-96C1-C2C6CDB900C5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{37D1D6B7-C4E5-44EC-96C1-C2C6CDB900C5}.Debug|x86.Build.0 = Debug|Any CPU
+		{37D1D6B7-C4E5-44EC-96C1-C2C6CDB900C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{37D1D6B7-C4E5-44EC-96C1-C2C6CDB900C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{37D1D6B7-C4E5-44EC-96C1-C2C6CDB900C5}.Release|x64.ActiveCfg = Release|Any CPU
+		{37D1D6B7-C4E5-44EC-96C1-C2C6CDB900C5}.Release|x64.Build.0 = Release|Any CPU
+		{37D1D6B7-C4E5-44EC-96C1-C2C6CDB900C5}.Release|x86.ActiveCfg = Release|Any CPU
+		{37D1D6B7-C4E5-44EC-96C1-C2C6CDB900C5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -174,5 +188,6 @@ Global
 		{B2E9D21C-6C01-4F28-AF7C-2EF16148E964} = {BA11C821-EFDE-4714-A0DE-B7D4D93CE336}
 		{2E8D3BE3-F419-46B1-BBD3-FC5F753261D0} = {10E2E10B-AB65-4800-93ED-CDB737917154}
 		{9601A06C-4C43-4E68-8576-F92BBFFEA73B} = {BA11C821-EFDE-4714-A0DE-B7D4D93CE336}
+		{37D1D6B7-C4E5-44EC-96C1-C2C6CDB900C5} = {10E2E10B-AB65-4800-93ED-CDB737917154}
 	EndGlobalSection
 EndGlobal

--- a/Atypical.VirtualFileSystem.sln
+++ b/Atypical.VirtualFileSystem.sln
@@ -25,6 +25,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atypical.VirtualFileSystem.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atypical.VirtualFileSystem.Providers.Abstractions", "src\Atypical.VirtualFileSystem.Providers.Abstractions\Atypical.VirtualFileSystem.Providers.Abstractions.csproj", "{B2E9D21C-6C01-4F28-AF7C-2EF16148E964}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atypical.VirtualFileSystem.Providers.Abstractions.Tests", "tests\Atypical.VirtualFileSystem.Providers.Abstractions.Tests\Atypical.VirtualFileSystem.Providers.Abstractions.Tests.csproj", "{2E8D3BE3-F419-46B1-BBD3-FC5F753261D0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -131,6 +133,18 @@ Global
 		{B2E9D21C-6C01-4F28-AF7C-2EF16148E964}.Release|x64.Build.0 = Release|Any CPU
 		{B2E9D21C-6C01-4F28-AF7C-2EF16148E964}.Release|x86.ActiveCfg = Release|Any CPU
 		{B2E9D21C-6C01-4F28-AF7C-2EF16148E964}.Release|x86.Build.0 = Release|Any CPU
+		{2E8D3BE3-F419-46B1-BBD3-FC5F753261D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E8D3BE3-F419-46B1-BBD3-FC5F753261D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E8D3BE3-F419-46B1-BBD3-FC5F753261D0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2E8D3BE3-F419-46B1-BBD3-FC5F753261D0}.Debug|x64.Build.0 = Debug|Any CPU
+		{2E8D3BE3-F419-46B1-BBD3-FC5F753261D0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2E8D3BE3-F419-46B1-BBD3-FC5F753261D0}.Debug|x86.Build.0 = Debug|Any CPU
+		{2E8D3BE3-F419-46B1-BBD3-FC5F753261D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E8D3BE3-F419-46B1-BBD3-FC5F753261D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E8D3BE3-F419-46B1-BBD3-FC5F753261D0}.Release|x64.ActiveCfg = Release|Any CPU
+		{2E8D3BE3-F419-46B1-BBD3-FC5F753261D0}.Release|x64.Build.0 = Release|Any CPU
+		{2E8D3BE3-F419-46B1-BBD3-FC5F753261D0}.Release|x86.ActiveCfg = Release|Any CPU
+		{2E8D3BE3-F419-46B1-BBD3-FC5F753261D0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -144,5 +158,6 @@ Global
 		{0F803EA9-AD74-46E3-9404-5D536E0F262C} = {BA11C821-EFDE-4714-A0DE-B7D4D93CE336}
 		{31971414-5519-4149-B5C0-C88454EBE7AD} = {10E2E10B-AB65-4800-93ED-CDB737917154}
 		{B2E9D21C-6C01-4F28-AF7C-2EF16148E964} = {BA11C821-EFDE-4714-A0DE-B7D4D93CE336}
+		{2E8D3BE3-F419-46B1-BBD3-FC5F753261D0} = {10E2E10B-AB65-4800-93ED-CDB737917154}
 	EndGlobalSection
 EndGlobal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,13 @@ IRootNode (vfs://)
 └── IFileNode (contains Content string)
 ```
 
+### Storage Providers
+External backends are plugged in behind a provider abstraction (the `Core` VFS itself stays storage-agnostic):
+- `Atypical.VirtualFileSystem.Providers.Abstractions` defines `IStorageProvider` (`ImportAsync`/`ReadFileAsync`/`WriteChangesAsync`/`GetAccountInfoAsync`), `IStorageProviderAuth`, `ProviderCapabilities`, and neutral records (`ProviderLoadOptions/Result`, `ProviderFileChange`, `CommitContext`, `ProviderFileMetadata`, `AuthRequest/Result`).
+- Branch/PR/fork are NOT base-interface methods — they are `ProviderCapabilities` flags plus `CommitContext` fields, so capable providers (GitHub) honor them and others (FTP) ignore them.
+- Implementations: `Atypical.VirtualFileSystem.GitHub` (`GitHubStorageProvider`, wraps the existing Octokit loader/write service via adapters — Token auth, supports branches/PR/fork) and `Atypical.VirtualFileSystem.Ftp` (`FtpStorageProvider` over FluentFTP — Credentials auth, read+write/overwrite, no branches/PR).
+- The Blazor app selects the active provider via `IStorageProviderRegistry` and drives its UI (import dialog fields, "submit changes") from `ProviderCapabilities`; FTP credentials and the GitHub PAT are persisted encrypted via `ProtectedLocalStorage`.
+
 ### Path System
 - `VFSRootPath` - Root directory (vfs://)
 - `VFSDirectoryPath` - Directory paths with case-insensitive comparison

--- a/docs/superpowers/plans/2026-06-02-storage-providers-foundation-ftp.md
+++ b/docs/superpowers/plans/2026-06-02-storage-providers-foundation-ftp.md
@@ -740,7 +740,7 @@ public sealed class GitHubStorageProvider : IStorageProvider
 
     public async Task<ProviderLoadResult> ImportAsync(IVirtualFileSystem vfs, ProviderLoadOptions options, CancellationToken cancellationToken = default)
     {
-        // RemoteRoot for GitHub is "owner/repo[/subpath]"; parse owner/repo and pass subpath via TargetPath.
+        // RemoteRoot for GitHub is "owner/repo[/subpath]"; parse owner/repo and pass subpath via the loader's SubPath (the remote filter), NOT TargetPath (the VFS destination).
         var (owner, repo, subPath) = ParseRemoteRoot(options.RemoteRoot);
         var ghOptions = GitHubProviderAdapters.ToGitHubLoaderOptions(options with { RemoteRoot = subPath }, _auth.Token);
         var result = await _loader.LoadRepositoryAsync(vfs, owner, repo, ghOptions, cancellationToken);

--- a/src/Atypical.VirtualFileSystem.DemoBlazorApp/Atypical.VirtualFileSystem.DemoBlazorApp.csproj
+++ b/src/Atypical.VirtualFileSystem.DemoBlazorApp/Atypical.VirtualFileSystem.DemoBlazorApp.csproj
@@ -13,6 +13,8 @@
   <ItemGroup>
     <ProjectReference Include="../Atypical.VirtualFileSystem.Core/Atypical.VirtualFileSystem.Core.csproj" />
     <ProjectReference Include="../Atypical.VirtualFileSystem.GitHub/Atypical.VirtualFileSystem.GitHub.csproj" />
+    <ProjectReference Include="../Atypical.VirtualFileSystem.Providers.Abstractions/Atypical.VirtualFileSystem.Providers.Abstractions.csproj" />
+    <ProjectReference Include="../Atypical.VirtualFileSystem.Ftp/Atypical.VirtualFileSystem.Ftp.csproj" />
   </ItemGroup>
 
   <!-- Tailwind CSS Build -->

--- a/src/Atypical.VirtualFileSystem.DemoBlazorApp/Components/Dialogs/CreatePullRequestDialog.razor
+++ b/src/Atypical.VirtualFileSystem.DemoBlazorApp/Components/Dialogs/CreatePullRequestDialog.razor
@@ -1,10 +1,12 @@
-@* Create Pull Request Dialog *@
+@* Capability-driven "Submit changes" dialog (PR for GitHub, upload for FTP) *@
 @inject GitHubPendingChangesService PendingChangesService
 @inject GitHubAuthService AuthService
 @inject ToastService Toast
+@inject StoragePendingChangesService StorageSubmit
+@inject IStorageProviderRegistry Registry
 @implements IDisposable
 
-<Modal @bind-IsOpen="IsOpen" Title="Create Pull Request" Size="xl" CloseOnBackdropClick="@(!_isCreating)">
+<Modal @bind-IsOpen="IsOpen" Title="@DialogTitle" Size="xl" CloseOnBackdropClick="@(!_isCreating)">
     <ChildContent>
         @if (_result is not null && _result.Success)
         {
@@ -91,6 +93,51 @@
                         </div>
                     }
                 </div>
+            </div>
+        }
+        else if (!SupportsPullRequests)
+        {
+            @* Non-PR provider (e.g. FTP): simple upload confirmation *@
+            <div class="space-y-4">
+                <div class="bg-blue-50 border border-blue-200 rounded-lg p-3">
+                    <div class="flex gap-2">
+                        <svg class="w-4 h-4 text-blue-500 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
+                        </svg>
+                        <span class="text-sm text-blue-700">
+                            @Registry.Active.DisplayName uploads changes directly to the remote — no pull request is created.
+                        </span>
+                    </div>
+                </div>
+
+                @if (_uploadChanges.Count == 0)
+                {
+                    <div class="bg-amber-50 border border-amber-200 rounded-lg p-3">
+                        <div class="flex gap-2">
+                            <svg class="w-4 h-4 text-amber-500 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
+                            </svg>
+                            <span class="text-sm text-amber-700">
+                                No tracked changes are available to upload for this provider yet.
+                            </span>
+                        </div>
+                    </div>
+                }
+                else
+                {
+                    <label class="block text-sm font-medium text-gray-700 mb-2">
+                        Files to upload (@_uploadChanges.Count)
+                    </label>
+                    <div class="border border-gray-200 rounded-lg max-h-48 overflow-y-auto">
+                        @foreach (var change in _uploadChanges)
+                        {
+                            <div class="flex items-center gap-2 px-3 py-2 border-b border-gray-100 last:border-b-0 text-sm">
+                                <span class="text-gray-700 truncate flex-1" title="@change.RemotePath">@change.RemotePath</span>
+                                <span class="text-xs text-gray-400">@change.Kind</span>
+                            </div>
+                        }
+                    </div>
+                }
             </div>
         }
         else
@@ -223,6 +270,16 @@
         {
             <span class="text-sm text-gray-500">Creating pull request...</span>
         }
+        else if (!SupportsPullRequests)
+        {
+            <Button Variant="ghost" OnClick="Close">Cancel</Button>
+            <Button Variant="primary"
+                    OnClick="UploadChanges"
+                    Disabled="@(_uploadChanges.Count == 0)"
+                    Icon="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5">
+                Upload changes
+            </Button>
+        }
         else
         {
             <Button Variant="ghost" OnClick="Close">Cancel</Button>
@@ -255,6 +312,15 @@
     private (string Owner, string Repository)? _repositoryInfo;
     private bool _wasOpen;
 
+    // Non-PR (upload) provider state.
+    private List<ProviderFileChange> _uploadChanges = new();
+
+    // Capability-driven view selectors.
+    private bool SupportsPullRequests => StorageSubmit.SupportsPullRequests;
+    private string DialogTitle => SupportsPullRequests
+        ? "Create Pull Request"
+        : $"Upload changes to {Registry.Active.DisplayName}";
+
     private bool CanCreate => AuthService.IsAuthenticated
                               && !string.IsNullOrWhiteSpace(_title)
                               && !string.IsNullOrWhiteSpace(_branchName)
@@ -264,6 +330,7 @@
     {
         PendingChangesService.OnPendingChangesChanged += LoadChanges;
         AuthService.OnCredentialsChanged += OnCredentialsChanged;
+        Registry.OnActiveProviderChanged += OnCredentialsChanged;
     }
 
     private void OnCredentialsChanged() => InvokeAsync(StateHasChanged);
@@ -396,6 +463,41 @@
         }
     }
 
+    // Non-PR providers (e.g. FTP): upload the tracked changes directly via the active provider.
+    // NOTE: FTP change-set tracking is not yet wired (see concern in the report); _uploadChanges
+    // is empty today, so this path is reached only once tracking is implemented.
+    private async Task UploadChanges()
+    {
+        if (_uploadChanges.Count == 0) return;
+
+        _isCreating = true;
+        StateHasChanged();
+
+        try
+        {
+            var writeResult = await StorageSubmit.SubmitAsync(_uploadChanges, CommitContext.Empty);
+            if (writeResult.Success)
+            {
+                Toast.ShowSuccess($"Uploaded {writeResult.FileResults.Count} file(s) successfully.");
+                _uploadChanges = new();
+                await Close();
+            }
+            else
+            {
+                Toast.ShowError(writeResult.Message ?? "One or more files failed to upload.");
+            }
+        }
+        catch (Exception ex)
+        {
+            Toast.ShowError($"Upload failed: {ex.Message}");
+        }
+        finally
+        {
+            _isCreating = false;
+            StateHasChanged();
+        }
+    }
+
     private void ResetDialog()
     {
         _result = null;
@@ -470,5 +572,6 @@
     {
         PendingChangesService.OnPendingChangesChanged -= LoadChanges;
         AuthService.OnCredentialsChanged -= OnCredentialsChanged;
+        Registry.OnActiveProviderChanged -= OnCredentialsChanged;
     }
 }

--- a/src/Atypical.VirtualFileSystem.DemoBlazorApp/Components/Dialogs/GitHubImportDialog.razor
+++ b/src/Atypical.VirtualFileSystem.DemoBlazorApp/Components/Dialogs/GitHubImportDialog.razor
@@ -1,15 +1,18 @@
-@* GitHub Repository Import Dialog *@
+@* Capability-driven storage import dialog (GitHub, FTP, ...) *@
 @inject IVirtualFileSystem VFS
 @inject GitHubImportService ImportService
 @inject VFSStateService StateService
 @inject ToastService Toast
 @inject NavigationManager Navigation
 @inject GitHubAuthService AuthService
+@inject IStorageProviderRegistry Registry
+@inject StorageImportService StorageImport
+@inject StorageCredentialStore CredentialStore
 @implements IDisposable
 
-<Modal @bind-IsOpen="IsOpen" Title="Import from GitHub" Size="lg" CloseOnBackdropClick="@(!ImportService.State.IsImporting)">
+<Modal @bind-IsOpen="IsOpen" Title="@DialogTitle" Size="lg" CloseOnBackdropClick="@(!IsBusy)">
     <ChildContent>
-        @if (ImportService.State.IsImporting)
+        @if (IsGitHub && ImportService.State.IsImporting)
         {
             @* Loading State *@
             <div class="space-y-4">
@@ -37,7 +40,7 @@
                 </div>
             </div>
         }
-        else if (!string.IsNullOrEmpty(ImportService.State.ErrorMessage))
+        else if (IsGitHub && !string.IsNullOrEmpty(ImportService.State.ErrorMessage))
         {
             @* Error State *@
             <div class="space-y-4">
@@ -59,6 +62,20 @@
         {
             @* Input Form *@
             <div class="space-y-4">
+                @* Provider Picker (capability-driven UI) *@
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Provider</label>
+                    <select class="input" value="@Registry.Active.Id" @onchange="OnProviderChanged">
+                        @foreach (var p in Registry.Providers)
+                        {
+                            <option value="@p.Id">@p.DisplayName</option>
+                        }
+                    </select>
+                </div>
+
+                @if (IsGitHub)
+                {
+                    @* ===== GitHub field set (SupportsBranches) ===== *@
                 @* Authentication Status *@
                 <div class="flex items-center justify-between p-3 rounded-lg @(AuthService.IsAuthenticated ? "bg-green-50 border border-green-200" : "bg-gray-50 border border-gray-200")">
                     <div class="flex items-center gap-2">
@@ -200,17 +217,106 @@
                         </div>
                     </div>
                 }
+                }
+                else if (IsCredentials)
+                {
+                    @* ===== Credentials field set (e.g. FTP) ===== *@
+                    @if (_ftpBusy)
+                    {
+                        <div class="flex items-center gap-3">
+                            <div class="animate-spin rounded-full h-5 w-5 border-b-2 border-cloud-600"></div>
+                            <span class="text-gray-700">@_ftpBusyMessage</span>
+                        </div>
+                    }
+                    else
+                    {
+                        @if (!string.IsNullOrEmpty(_ftpError))
+                        {
+                            <div class="bg-red-50 border border-red-200 rounded-lg p-4">
+                                <div class="flex gap-3">
+                                    <svg class="w-5 h-5 text-red-500 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
+                                    </svg>
+                                    <div>
+                                        <h4 class="text-sm font-medium text-red-800">Import Failed</h4>
+                                        <p class="text-sm text-red-700 mt-1">@_ftpError</p>
+                                    </div>
+                                </div>
+                            </div>
+                        }
+
+                        @if (_ftpResult is not null)
+                        {
+                            <div class="bg-green-50 border border-green-200 rounded-lg p-4">
+                                <div class="flex gap-3">
+                                    <svg class="w-5 h-5 text-green-500 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                                    </svg>
+                                    <div>
+                                        <h4 class="text-sm font-medium text-green-800">Import Complete</h4>
+                                        <p class="text-sm text-green-700 mt-1">
+                                            Imported @_ftpResult.FilesLoaded files (@_ftpResult.Skipped.Count skipped) from @_ftpResult.RemoteRoot
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                        }
+
+                        <div class="grid grid-cols-3 gap-4">
+                            <div class="col-span-2">
+                                <label class="block text-sm font-medium text-gray-700 mb-1">Host</label>
+                                <input type="text" class="input" placeholder="ftp.example.com" @bind="_ftpHost" />
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1">Port</label>
+                                <input type="number" class="input" min="1" max="65535" @bind="_ftpPort" />
+                            </div>
+                        </div>
+
+                        <div class="grid grid-cols-2 gap-4">
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1">Username</label>
+                                <input type="text" class="input" placeholder="anonymous" @bind="_ftpUsername" />
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1">Password</label>
+                                <input type="password" class="input" @bind="_ftpPassword" />
+                            </div>
+                        </div>
+
+                        <div class="flex items-center gap-2">
+                            <input type="checkbox" id="ftpUseTls" class="w-4 h-4 text-cloud-600 rounded border-gray-300" @bind="_ftpUseTls" />
+                            <label for="ftpUseTls" class="text-sm text-gray-700">Use TLS (explicit FTPS)</label>
+                        </div>
+
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 mb-1">Base Path</label>
+                            <input type="text" class="input" placeholder="/" @bind="_ftpBasePath" />
+                            <p class="text-xs text-gray-500 mt-1">Remote directory to import from (defaults to /)</p>
+                        </div>
+                    }
+                }
             </div>
         }
     </ChildContent>
     <Footer>
-        @if (ImportService.State.IsImporting)
+        @if (IsGitHub && ImportService.State.IsImporting)
         {
             <Button Variant="danger" OnClick="CancelImport">Cancel</Button>
         }
-        else if (!string.IsNullOrEmpty(ImportService.State.ErrorMessage))
+        else if (IsGitHub && !string.IsNullOrEmpty(ImportService.State.ErrorMessage))
         {
             <Button Variant="ghost" OnClick="Close">Close</Button>
+        }
+        else if (IsCredentials)
+        {
+            <Button Variant="ghost" OnClick="Close" Disabled="@_ftpBusy">Cancel</Button>
+            <Button Variant="primary"
+                    OnClick="StartFtpImport"
+                    Disabled="@(!CanImportFtp)"
+                    Icon="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5">
+                Import
+            </Button>
         }
         else
         {
@@ -242,18 +348,74 @@
     private bool _excludeBinaryFiles = false;
     private bool _showAdvanced = false;
 
+    // FTP / credentials provider fields
+    private string _ftpHost = "";
+    private int _ftpPort = 21;
+    private string _ftpUsername = "";
+    private string _ftpPassword = "";
+    private bool _ftpUseTls = false;
+    private string _ftpBasePath = "/";
+    private bool _ftpBusy = false;
+    private string _ftpBusyMessage = "";
+    private string? _ftpError;
+    private ProviderLoadResult? _ftpResult;
+    private string? _credentialsLoadedFor;
+
+    // Capability-driven view selectors based on the active provider.
+    private bool IsGitHub => Registry.Active.Capabilities.SupportsBranches;
+    private bool IsCredentials => Registry.Active.Capabilities.AuthKind == AuthKind.Credentials;
+    private bool IsBusy => (IsGitHub && ImportService.State.IsImporting) || _ftpBusy;
+    private string DialogTitle => $"Import from {Registry.Active.DisplayName}";
+
     private bool CanImport => !string.IsNullOrWhiteSpace(_owner) && !string.IsNullOrWhiteSpace(_repository);
+    private bool CanImportFtp => !_ftpBusy && !string.IsNullOrWhiteSpace(_ftpHost);
 
     protected override async Task OnInitializedAsync()
     {
         ImportService.OnStateChanged += OnServiceStateChanged;
         AuthService.OnCredentialsChanged += OnServiceStateChanged;
+        StorageImport.OnStateChanged += OnServiceStateChanged;
+        Registry.OnActiveProviderChanged += OnServiceStateChanged;
         await AuthService.InitializeAsync();
+        await TryLoadCredentialsAsync();
     }
 
     // Import progress and credential validation run on awaited HTTP continuations
     // that may resume off the Dispatcher, so marshal back before rendering.
     private void OnServiceStateChanged() => InvokeAsync(StateHasChanged);
+
+    private async Task OnProviderChanged(ChangeEventArgs e)
+    {
+        Registry.SetActive(e.Value?.ToString() ?? Registry.Active.Id);
+        // Reset transient FTP state when switching providers.
+        _ftpError = null;
+        _ftpResult = null;
+        await TryLoadCredentialsAsync();
+        StateHasChanged();
+    }
+
+    // Pre-fill credential fields for credentials-based providers (e.g. FTP) from encrypted storage.
+    private async Task TryLoadCredentialsAsync()
+    {
+        if (!IsCredentials)
+            return;
+
+        var providerId = Registry.Active.Id;
+        if (_credentialsLoadedFor == providerId)
+            return;
+
+        _credentialsLoadedFor = providerId;
+        var saved = await CredentialStore.LoadAsync(providerId);
+        if (saved is not null)
+        {
+            _ftpHost = saved.Host ?? "";
+            _ftpPort = saved.Port == 0 ? 21 : saved.Port;
+            _ftpUsername = saved.Username ?? "";
+            _ftpPassword = saved.Password ?? "";
+            _ftpUseTls = saved.UseTls;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
 
     private async Task OpenGitHubSettings()
     {
@@ -317,6 +479,69 @@
         }
     }
 
+    // Credentials-based (FTP) import: authenticate via the active provider's Auth, persist the
+    // credentials, then delegate to the provider-neutral StorageImportService.
+    private async Task StartFtpImport()
+    {
+        if (!CanImportFtp) return;
+
+        _ftpError = null;
+        _ftpResult = null;
+        _ftpBusy = true;
+        _ftpBusyMessage = "Connecting...";
+        StateHasChanged();
+
+        var providerId = Registry.Active.Id;
+        var authRequest = new AuthRequest
+        {
+            Host = _ftpHost,
+            Port = _ftpPort,
+            Username = _ftpUsername,
+            Password = _ftpPassword,
+            UseTls = _ftpUseTls
+        };
+
+        try
+        {
+            var authResult = await Registry.Active.Auth.AuthenticateAsync(authRequest);
+            if (!authResult.Success)
+            {
+                _ftpError = authResult.ErrorMessage ?? "Authentication failed.";
+                return;
+            }
+
+            // Persist credentials for next time (best-effort; prerender-safe inside the store).
+            await CredentialStore.SaveAsync(providerId, authRequest);
+
+            _ftpBusyMessage = "Importing files...";
+            await InvokeAsync(StateHasChanged);
+
+            var options = new ProviderLoadOptions
+            {
+                RemoteRoot = string.IsNullOrWhiteSpace(_ftpBasePath) ? "/" : _ftpBasePath
+            };
+
+            _ftpResult = await StorageImport.ImportAsync(options);
+
+            var message = _ftpResult.Skipped.Count > 0
+                ? $"Imported {_ftpResult.FilesLoaded} files ({_ftpResult.Skipped.Count} skipped)"
+                : $"Imported {_ftpResult.FilesLoaded} files successfully";
+            Toast.ShowSuccess(message);
+
+            StateService.NotifyDataChanged();
+            await OnImportComplete.InvokeAsync(StateService.CurrentPath);
+        }
+        catch (Exception ex)
+        {
+            _ftpError = ex.Message;
+        }
+        finally
+        {
+            _ftpBusy = false;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
     private void CancelImport()
     {
         ImportService.CancelImport();
@@ -341,6 +566,8 @@
         _includeExtensions = "";
         _excludeBinaryFiles = false;
         _showAdvanced = false;
+        _ftpError = null;
+        _ftpResult = null;
         await IsOpenChanged.InvokeAsync(false);
     }
 
@@ -348,5 +575,7 @@
     {
         ImportService.OnStateChanged -= OnServiceStateChanged;
         AuthService.OnCredentialsChanged -= OnServiceStateChanged;
+        StorageImport.OnStateChanged -= OnServiceStateChanged;
+        Registry.OnActiveProviderChanged -= OnServiceStateChanged;
     }
 }

--- a/src/Atypical.VirtualFileSystem.DemoBlazorApp/Components/Dialogs/GitHubImportDialog.razor
+++ b/src/Atypical.VirtualFileSystem.DemoBlazorApp/Components/Dialogs/GitHubImportDialog.razor
@@ -391,7 +391,7 @@
         _ftpError = null;
         _ftpResult = null;
         await TryLoadCredentialsAsync();
-        StateHasChanged();
+        await InvokeAsync(StateHasChanged);
     }
 
     // Pre-fill credential fields for credentials-based providers (e.g. FTP) from encrypted storage.
@@ -489,7 +489,7 @@
         _ftpResult = null;
         _ftpBusy = true;
         _ftpBusyMessage = "Connecting...";
-        StateHasChanged();
+        await InvokeAsync(StateHasChanged);
 
         var providerId = Registry.Active.Id;
         var authRequest = new AuthRequest
@@ -566,6 +566,9 @@
         _includeExtensions = "";
         _excludeBinaryFiles = false;
         _showAdvanced = false;
+        // Only transient FTP state is reset here; the credential fields
+        // (_ftpHost/_ftpUsername/etc.) are intentionally NOT cleared so they
+        // re-prefill from the credential store next time the dialog opens.
         _ftpError = null;
         _ftpResult = null;
         await IsOpenChanged.InvokeAsync(false);

--- a/src/Atypical.VirtualFileSystem.DemoBlazorApp/Components/_Imports.razor
+++ b/src/Atypical.VirtualFileSystem.DemoBlazorApp/Components/_Imports.razor
@@ -21,3 +21,4 @@
 @using Atypical.VirtualFileSystem.Core.Contracts
 @using Atypical.VirtualFileSystem.Core.Extensions
 @using Atypical.VirtualFileSystem.GitHub
+@using Atypical.VirtualFileSystem.Providers.Abstractions

--- a/src/Atypical.VirtualFileSystem.DemoBlazorApp/Program.cs
+++ b/src/Atypical.VirtualFileSystem.DemoBlazorApp/Program.cs
@@ -49,6 +49,7 @@ builder.Services.AddScoped<IStorageProviderRegistry, StorageProviderRegistry>();
 // Provider-neutral credential store and import service
 builder.Services.AddScoped<StorageCredentialStore>();
 builder.Services.AddScoped<StorageImportService>();
+builder.Services.AddScoped<StoragePendingChangesService>();
 
 var app = builder.Build();
 

--- a/src/Atypical.VirtualFileSystem.DemoBlazorApp/Program.cs
+++ b/src/Atypical.VirtualFileSystem.DemoBlazorApp/Program.cs
@@ -1,6 +1,10 @@
 using Atypical.VirtualFileSystem.DemoBlazorApp.Components;
+using Atypical.VirtualFileSystem.DemoBlazorApp.Services;
 using Atypical.VirtualFileSystem.Core.Services;
+using Atypical.VirtualFileSystem.Ftp;
 using Atypical.VirtualFileSystem.GitHub;
+using Atypical.VirtualFileSystem.GitHub.Providers;
+using Atypical.VirtualFileSystem.Providers.Abstractions;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -30,6 +34,16 @@ builder.Services.AddScoped<Atypical.VirtualFileSystem.DemoBlazorApp.Services.Git
 builder.Services.AddScoped<Atypical.VirtualFileSystem.DemoBlazorApp.Services.GitHubMetadataTracker>();
 builder.Services.AddScoped<Atypical.VirtualFileSystem.DemoBlazorApp.Services.GitHubPendingChangesService>();
 builder.Services.AddScoped<IGitHubWriteService, GitHubWriteService>();
+
+// Storage providers (neutral abstraction layer — alongside existing GitHub services)
+builder.Services.AddVirtualFileSystemFtp();
+builder.Services.AddScoped<GitHubProviderAuth>();
+builder.Services.AddScoped<GitHubStorageProvider>();
+
+// Expose both providers as IStorageProvider so the registry receives them via IEnumerable<IStorageProvider>
+builder.Services.AddScoped<IStorageProvider>(sp => sp.GetRequiredService<GitHubStorageProvider>());
+builder.Services.AddScoped<IStorageProvider>(sp => sp.GetRequiredService<FtpStorageProvider>());
+builder.Services.AddScoped<IStorageProviderRegistry, StorageProviderRegistry>();
 
 var app = builder.Build();
 

--- a/src/Atypical.VirtualFileSystem.DemoBlazorApp/Program.cs
+++ b/src/Atypical.VirtualFileSystem.DemoBlazorApp/Program.cs
@@ -45,6 +45,10 @@ builder.Services.AddScoped<IStorageProvider>(sp => sp.GetRequiredService<GitHubS
 builder.Services.AddScoped<IStorageProvider>(sp => sp.GetRequiredService<FtpStorageProvider>());
 builder.Services.AddScoped<IStorageProviderRegistry, StorageProviderRegistry>();
 
+// Provider-neutral credential store and import service
+builder.Services.AddScoped<StorageCredentialStore>();
+builder.Services.AddScoped<StorageImportService>();
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.

--- a/src/Atypical.VirtualFileSystem.DemoBlazorApp/Program.cs
+++ b/src/Atypical.VirtualFileSystem.DemoBlazorApp/Program.cs
@@ -40,7 +40,8 @@ builder.Services.AddVirtualFileSystemFtp();
 builder.Services.AddScoped<GitHubProviderAuth>();
 builder.Services.AddScoped<GitHubStorageProvider>();
 
-// Expose both providers as IStorageProvider so the registry receives them via IEnumerable<IStorageProvider>
+// Expose both providers as IStorageProvider so the registry receives them via IEnumerable<IStorageProvider>.
+// Registration order is intentional: it determines the registry's default active provider (GitHub first = default).
 builder.Services.AddScoped<IStorageProvider>(sp => sp.GetRequiredService<GitHubStorageProvider>());
 builder.Services.AddScoped<IStorageProvider>(sp => sp.GetRequiredService<FtpStorageProvider>());
 builder.Services.AddScoped<IStorageProviderRegistry, StorageProviderRegistry>();

--- a/src/Atypical.VirtualFileSystem.DemoBlazorApp/Services/IStorageProviderRegistry.cs
+++ b/src/Atypical.VirtualFileSystem.DemoBlazorApp/Services/IStorageProviderRegistry.cs
@@ -18,5 +18,5 @@ public interface IStorageProviderRegistry
     void SetActive(string providerId);
 
     /// <summary>Raised whenever <see cref="Active"/> changes.</summary>
-    event Action? ActiveProviderChanged;
+    event Action? OnActiveProviderChanged;
 }

--- a/src/Atypical.VirtualFileSystem.DemoBlazorApp/Services/IStorageProviderRegistry.cs
+++ b/src/Atypical.VirtualFileSystem.DemoBlazorApp/Services/IStorageProviderRegistry.cs
@@ -1,0 +1,22 @@
+using Atypical.VirtualFileSystem.Providers.Abstractions;
+
+namespace Atypical.VirtualFileSystem.DemoBlazorApp.Services;
+
+/// <summary>
+/// Tracks the registered <see cref="IStorageProvider"/> instances and exposes the currently active one.
+/// </summary>
+public interface IStorageProviderRegistry
+{
+    /// <summary>All registered providers, in registration order.</summary>
+    IReadOnlyList<IStorageProvider> Providers { get; }
+
+    /// <summary>The currently active provider. Defaults to the first registered provider.</summary>
+    IStorageProvider Active { get; }
+
+    /// <summary>Switches the active provider to the one with the given <paramref name="providerId"/>.</summary>
+    /// <exception cref="ArgumentException">Thrown when no provider with the given id is registered.</exception>
+    void SetActive(string providerId);
+
+    /// <summary>Raised whenever <see cref="Active"/> changes.</summary>
+    event Action? ActiveProviderChanged;
+}

--- a/src/Atypical.VirtualFileSystem.DemoBlazorApp/Services/StorageCredentialStore.cs
+++ b/src/Atypical.VirtualFileSystem.DemoBlazorApp/Services/StorageCredentialStore.cs
@@ -1,0 +1,58 @@
+using Atypical.VirtualFileSystem.Providers.Abstractions;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+
+namespace Atypical.VirtualFileSystem.DemoBlazorApp.Services;
+
+/// <summary>
+/// Persists per-provider <see cref="AuthRequest"/> payloads in encrypted browser local storage
+/// (via <see cref="ProtectedLocalStorage"/>). All access is wrapped in try/catch so that the
+/// service is prerender-safe (JS interop is unavailable during static prerendering).
+/// </summary>
+public sealed class StorageCredentialStore
+{
+    private readonly ProtectedLocalStorage _storage;
+
+    public StorageCredentialStore(ProtectedLocalStorage storage) => _storage = storage;
+
+    private static string Key(string providerId) => $"provider_creds_{providerId}";
+
+    /// <summary>Saves the credentials for <paramref name="providerId"/> to encrypted local storage.</summary>
+    public async Task SaveAsync(string providerId, AuthRequest request)
+    {
+        try
+        {
+            await _storage.SetAsync(Key(providerId), request);
+        }
+        catch
+        {
+            // Silently fail: JS interop unavailable during prerender, or storage is locked.
+        }
+    }
+
+    /// <summary>Loads previously saved credentials for <paramref name="providerId"/>, or null if none.</summary>
+    public async Task<AuthRequest?> LoadAsync(string providerId)
+    {
+        try
+        {
+            var result = await _storage.GetAsync<AuthRequest>(Key(providerId));
+            return result.Success ? result.Value : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Removes stored credentials for <paramref name="providerId"/>.</summary>
+    public async Task ClearAsync(string providerId)
+    {
+        try
+        {
+            await _storage.DeleteAsync(Key(providerId));
+        }
+        catch
+        {
+            // Silently fail: unavailable during prerender.
+        }
+    }
+}

--- a/src/Atypical.VirtualFileSystem.DemoBlazorApp/Services/StorageImportService.cs
+++ b/src/Atypical.VirtualFileSystem.DemoBlazorApp/Services/StorageImportService.cs
@@ -1,0 +1,46 @@
+using Atypical.VirtualFileSystem.Core.Contracts;
+using Atypical.VirtualFileSystem.Providers.Abstractions;
+
+namespace Atypical.VirtualFileSystem.DemoBlazorApp.Services;
+
+/// <summary>
+/// Provider-neutral import service that delegates <see cref="ImportAsync"/> to whichever
+/// <see cref="IStorageProvider"/> is currently active in the <see cref="IStorageProviderRegistry"/>.
+/// Exposes <see cref="IsImporting"/> and <see cref="OnStateChanged"/> so UI components can
+/// react to import progress without being coupled to a specific provider.
+/// </summary>
+public sealed class StorageImportService
+{
+    private readonly IStorageProviderRegistry _registry;
+    private readonly IVirtualFileSystem _vfs;
+
+    public StorageImportService(IStorageProviderRegistry registry, IVirtualFileSystem vfs)
+    {
+        _registry = registry;
+        _vfs = vfs;
+    }
+
+    /// <summary>Raised when <see cref="IsImporting"/> changes (import started or finished).</summary>
+    public event Action? OnStateChanged;
+
+    /// <summary>True while an import is in progress.</summary>
+    public bool IsImporting { get; private set; }
+
+    /// <summary>
+    /// Imports into the VFS using the active provider and the supplied <paramref name="options"/>.
+    /// </summary>
+    public async Task<ProviderLoadResult> ImportAsync(ProviderLoadOptions options, CancellationToken ct = default)
+    {
+        IsImporting = true;
+        OnStateChanged?.Invoke();
+        try
+        {
+            return await _registry.Active.ImportAsync(_vfs, options, ct);
+        }
+        finally
+        {
+            IsImporting = false;
+            OnStateChanged?.Invoke();
+        }
+    }
+}

--- a/src/Atypical.VirtualFileSystem.DemoBlazorApp/Services/StorageImportService.cs
+++ b/src/Atypical.VirtualFileSystem.DemoBlazorApp/Services/StorageImportService.cs
@@ -31,6 +31,9 @@ public sealed class StorageImportService
     /// </summary>
     public async Task<ProviderLoadResult> ImportAsync(ProviderLoadOptions options, CancellationToken ct = default)
     {
+        if (IsImporting)
+            throw new InvalidOperationException("An import is already in progress.");
+
         IsImporting = true;
         OnStateChanged?.Invoke();
         try

--- a/src/Atypical.VirtualFileSystem.DemoBlazorApp/Services/StoragePendingChangesService.cs
+++ b/src/Atypical.VirtualFileSystem.DemoBlazorApp/Services/StoragePendingChangesService.cs
@@ -34,5 +34,11 @@ public sealed class StoragePendingChangesService
         IReadOnlyList<ProviderFileChange> changes,
         CommitContext context,
         CancellationToken cancellationToken = default)
-        => _registry.Active.WriteChangesAsync(changes, context, cancellationToken);
+    {
+        if (SupportsPullRequests)
+            throw new InvalidOperationException(
+                "Use the PR flow (GitHubPendingChangesService) for pull-request-capable providers.");
+
+        return _registry.Active.WriteChangesAsync(changes, context, cancellationToken);
+    }
 }

--- a/src/Atypical.VirtualFileSystem.DemoBlazorApp/Services/StoragePendingChangesService.cs
+++ b/src/Atypical.VirtualFileSystem.DemoBlazorApp/Services/StoragePendingChangesService.cs
@@ -1,0 +1,38 @@
+using Atypical.VirtualFileSystem.Providers.Abstractions;
+
+namespace Atypical.VirtualFileSystem.DemoBlazorApp.Services;
+
+/// <summary>
+/// Provider-neutral "submit changes" service. It exposes the active provider's submit
+/// capability and routes a set of <see cref="ProviderFileChange"/> to the active provider's
+/// <see cref="IStorageProvider.WriteChangesAsync"/>.
+/// </summary>
+/// <remarks>
+/// For pull-request-capable providers (GitHub) the existing
+/// <see cref="GitHubPendingChangesService"/> fork-&gt;branch-&gt;commit-&gt;PR orchestration is the
+/// real submit path used by the UI; this service is used for non-PR providers (e.g. FTP),
+/// which upload changes directly. The capability flag lets the UI decide which path to show.
+/// </remarks>
+public sealed class StoragePendingChangesService
+{
+    private readonly IStorageProviderRegistry _registry;
+
+    public StoragePendingChangesService(IStorageProviderRegistry registry)
+        => _registry = registry;
+
+    /// <summary>True when the active provider supports pull requests (GitHub); false for FTP.</summary>
+    public bool SupportsPullRequests => _registry.Active.Capabilities.SupportsPullRequests;
+
+    /// <summary>The active provider's display name, for UI labelling.</summary>
+    public string ActiveProviderName => _registry.Active.DisplayName;
+
+    /// <summary>
+    /// Submits <paramref name="changes"/> to the active provider. For non-PR providers this
+    /// uploads/deletes files directly and returns a per-file <see cref="ProviderWriteResult"/>.
+    /// </summary>
+    public Task<ProviderWriteResult> SubmitAsync(
+        IReadOnlyList<ProviderFileChange> changes,
+        CommitContext context,
+        CancellationToken cancellationToken = default)
+        => _registry.Active.WriteChangesAsync(changes, context, cancellationToken);
+}

--- a/src/Atypical.VirtualFileSystem.DemoBlazorApp/Services/StorageProviderRegistry.cs
+++ b/src/Atypical.VirtualFileSystem.DemoBlazorApp/Services/StorageProviderRegistry.cs
@@ -1,0 +1,47 @@
+using Atypical.VirtualFileSystem.Providers.Abstractions;
+
+namespace Atypical.VirtualFileSystem.DemoBlazorApp.Services;
+
+/// <summary>
+/// Default implementation of <see cref="IStorageProviderRegistry"/>.
+/// Scoped per Blazor Server circuit; the active provider defaults to the first registered provider.
+/// </summary>
+public sealed class StorageProviderRegistry : IStorageProviderRegistry
+{
+    private IStorageProvider _active;
+
+    /// <inheritdoc />
+    public IReadOnlyList<IStorageProvider> Providers { get; }
+
+    /// <inheritdoc />
+    public event Action? ActiveProviderChanged;
+
+    /// <summary>
+    /// Creates a registry from all <see cref="IStorageProvider"/> instances registered in DI.
+    /// </summary>
+    /// <param name="providers">The full set of registered providers (injected as IEnumerable).</param>
+    /// <exception cref="InvalidOperationException">Thrown when the provider list is empty.</exception>
+    public StorageProviderRegistry(IEnumerable<IStorageProvider> providers)
+    {
+        Providers = providers.ToList();
+        if (Providers.Count == 0)
+            throw new InvalidOperationException("No storage providers registered.");
+        _active = Providers[0];
+    }
+
+    /// <inheritdoc />
+    public IStorageProvider Active => _active;
+
+    /// <inheritdoc />
+    public void SetActive(string providerId)
+    {
+        var match = Providers.FirstOrDefault(p => p.Id == providerId)
+            ?? throw new ArgumentException($"Unknown provider '{providerId}'.", nameof(providerId));
+
+        if (!ReferenceEquals(match, _active))
+        {
+            _active = match;
+            ActiveProviderChanged?.Invoke();
+        }
+    }
+}

--- a/src/Atypical.VirtualFileSystem.DemoBlazorApp/Services/StorageProviderRegistry.cs
+++ b/src/Atypical.VirtualFileSystem.DemoBlazorApp/Services/StorageProviderRegistry.cs
@@ -14,7 +14,7 @@ public sealed class StorageProviderRegistry : IStorageProviderRegistry
     public IReadOnlyList<IStorageProvider> Providers { get; }
 
     /// <inheritdoc />
-    public event Action? ActiveProviderChanged;
+    public event Action? OnActiveProviderChanged;
 
     /// <summary>
     /// Creates a registry from all <see cref="IStorageProvider"/> instances registered in DI.
@@ -41,7 +41,7 @@ public sealed class StorageProviderRegistry : IStorageProviderRegistry
         if (!ReferenceEquals(match, _active))
         {
             _active = match;
-            ActiveProviderChanged?.Invoke();
+            OnActiveProviderChanged?.Invoke();
         }
     }
 }

--- a/src/Atypical.VirtualFileSystem.Ftp/Atypical.VirtualFileSystem.Ftp.csproj
+++ b/src/Atypical.VirtualFileSystem.Ftp/Atypical.VirtualFileSystem.Ftp.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>Atypical.VirtualFileSystem.Ftp</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentFTP" Version="54.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <ProjectReference Include="..\Atypical.VirtualFileSystem.Core\Atypical.VirtualFileSystem.Core.csproj" />
+    <ProjectReference Include="..\Atypical.VirtualFileSystem.Providers.Abstractions\Atypical.VirtualFileSystem.Providers.Abstractions.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Atypical.VirtualFileSystem.Ftp/FluentFtpConnection.cs
+++ b/src/Atypical.VirtualFileSystem.Ftp/FluentFtpConnection.cs
@@ -1,0 +1,48 @@
+using FluentFTP;
+
+namespace Atypical.VirtualFileSystem.Ftp;
+
+/// <summary>
+/// Wraps <see cref="AsyncFtpClient"/> from FluentFTP (v54.x).
+/// Recursive listing is handled by <see cref="FtpStorageProvider"/>; this lists one directory at a time.
+/// </summary>
+public sealed class FluentFtpConnection : IFtpConnection, IAsyncDisposable
+{
+    private readonly AsyncFtpClient _client;
+
+    public FluentFtpConnection(FtpConnectionSettings settings)
+    {
+        _client = new AsyncFtpClient(settings.Host, settings.Username, settings.Password, settings.Port);
+        _client.Config.EncryptionMode = settings.UseTls ? FtpEncryptionMode.Explicit : FtpEncryptionMode.None;
+        // For demo purposes, accept any certificate when TLS is enabled; document for production hardening.
+        _client.Config.ValidateAnyCertificate = settings.UseTls;
+    }
+
+    public Task ConnectAsync(CancellationToken ct) => _client.Connect(ct);
+    public Task DisconnectAsync(CancellationToken ct) => _client.Disconnect(ct);
+
+    public async Task<IReadOnlyList<FtpRemoteItem>> ListAsync(string remoteDir, CancellationToken ct)
+    {
+        // GetListing(string path, CancellationToken token) → Task<FtpListItem[]>
+        var items = await _client.GetListing(remoteDir, ct);
+        return items.Select(i => new FtpRemoteItem(
+            i.FullName,
+            i.Type == FtpObjectType.Directory,
+            i.Size,
+            i.Modified.ToUniversalTime())).ToList();
+    }
+
+    public Task<byte[]> DownloadAsync(string remotePath, CancellationToken ct)
+        // DownloadBytes(string remotePath, CancellationToken token) → Task<byte[]>
+        => _client.DownloadBytes(remotePath, ct);
+
+    public async Task UploadAsync(string remotePath, byte[] content, CancellationToken ct)
+        // UploadBytes(byte[] fileData, string remotePath, FtpRemoteExists existsMode, bool createRemoteDir,
+        //             IProgress<FtpProgress> progress, CancellationToken token) → Task<FtpStatus>
+        => await _client.UploadBytes(content, remotePath, FtpRemoteExists.Overwrite, createRemoteDir: true, progress: null, token: ct);
+
+    public Task DeleteFileAsync(string remotePath, CancellationToken ct)
+        => _client.DeleteFile(remotePath, ct);
+
+    public async ValueTask DisposeAsync() => await _client.DisposeAsync();
+}

--- a/src/Atypical.VirtualFileSystem.Ftp/FluentFtpConnection.cs
+++ b/src/Atypical.VirtualFileSystem.Ftp/FluentFtpConnection.cs
@@ -14,8 +14,9 @@ public sealed class FluentFtpConnection : IFtpConnection, IAsyncDisposable
     {
         _client = new AsyncFtpClient(settings.Host, settings.Username, settings.Password, settings.Port);
         _client.Config.EncryptionMode = settings.UseTls ? FtpEncryptionMode.Explicit : FtpEncryptionMode.None;
-        // For demo purposes, accept any certificate when TLS is enabled; document for production hardening.
-        _client.Config.ValidateAnyCertificate = settings.UseTls;
+        // Validate server certificates by default; skip validation only when explicitly opted in
+        // (e.g. for a trusted self-signed test server).
+        _client.Config.ValidateAnyCertificate = settings is { UseTls: true, AllowInvalidCertificate: true };
     }
 
     public Task ConnectAsync(CancellationToken ct) => _client.Connect(ct);
@@ -29,7 +30,7 @@ public sealed class FluentFtpConnection : IFtpConnection, IAsyncDisposable
             i.FullName,
             i.Type == FtpObjectType.Directory,
             i.Size,
-            i.Modified.ToUniversalTime())).ToList();
+            new DateTimeOffset(i.Modified.ToUniversalTime(), TimeSpan.Zero))).ToList();
     }
 
     public Task<byte[]> DownloadAsync(string remotePath, CancellationToken ct)

--- a/src/Atypical.VirtualFileSystem.Ftp/FluentFtpConnectionFactory.cs
+++ b/src/Atypical.VirtualFileSystem.Ftp/FluentFtpConnectionFactory.cs
@@ -1,0 +1,8 @@
+namespace Atypical.VirtualFileSystem.Ftp;
+
+/// <summary>The production <see cref="IFtpConnectionFactory"/> that creates FluentFTP-backed connections.</summary>
+public sealed class FluentFtpConnectionFactory : IFtpConnectionFactory
+{
+    /// <inheritdoc />
+    public IFtpConnection Create(FtpConnectionSettings settings) => new FluentFtpConnection(settings);
+}

--- a/src/Atypical.VirtualFileSystem.Ftp/FtpConnectionSettings.cs
+++ b/src/Atypical.VirtualFileSystem.Ftp/FtpConnectionSettings.cs
@@ -1,0 +1,10 @@
+namespace Atypical.VirtualFileSystem.Ftp;
+
+public sealed record FtpConnectionSettings
+{
+    public required string Host { get; init; }
+    public int Port { get; init; } = 21;
+    public string? Username { get; init; }
+    public string? Password { get; init; }
+    public bool UseTls { get; init; }
+}

--- a/src/Atypical.VirtualFileSystem.Ftp/FtpConnectionSettings.cs
+++ b/src/Atypical.VirtualFileSystem.Ftp/FtpConnectionSettings.cs
@@ -1,10 +1,28 @@
 namespace Atypical.VirtualFileSystem.Ftp;
 
+/// <summary>
+/// Connection parameters used to open an FTP/FTPS session.
+/// </summary>
 public sealed record FtpConnectionSettings
 {
+    /// <summary>The FTP server host name or IP address.</summary>
     public required string Host { get; init; }
+
+    /// <summary>The FTP control-channel port. Defaults to 21.</summary>
     public int Port { get; init; } = 21;
+
+    /// <summary>The user name used to authenticate, or <c>null</c> for anonymous access.</summary>
     public string? Username { get; init; }
+
+    /// <summary>The password used to authenticate, or <c>null</c> for anonymous access.</summary>
     public string? Password { get; init; }
+
+    /// <summary>When <c>true</c>, connects using explicit FTPS (TLS).</summary>
     public bool UseTls { get; init; }
+
+    /// <summary>
+    /// When <c>true</c>, accepts any server certificate without validation (TLS only).
+    /// Defaults to <c>false</c>; enable only for trusted test servers.
+    /// </summary>
+    public bool AllowInvalidCertificate { get; init; }
 }

--- a/src/Atypical.VirtualFileSystem.Ftp/FtpProviderAuth.cs
+++ b/src/Atypical.VirtualFileSystem.Ftp/FtpProviderAuth.cs
@@ -1,17 +1,32 @@
 namespace Atypical.VirtualFileSystem.Ftp;
 
+/// <summary>
+/// Credentials-based authentication for the FTP provider. Validates credentials by opening
+/// (and immediately closing) a connection, and exposes the resulting <see cref="FtpConnectionSettings"/>.
+/// </summary>
 public sealed class FtpProviderAuth : IStorageProviderAuth
 {
     private readonly Func<FtpConnectionSettings, IFtpConnection> _factory;
 
+    /// <summary>Creates the auth helper using the given connection factory.</summary>
     public FtpProviderAuth(Func<FtpConnectionSettings, IFtpConnection> factory) => _factory = factory;
 
+    /// <inheritdoc />
     public AuthKind Kind => AuthKind.Credentials;
+
+    /// <inheritdoc />
     public bool IsAuthenticated => Settings is not null;
+
+    /// <inheritdoc />
     public ProviderAccountInfo? Account { get; private set; }
+
+    /// <summary>The validated connection settings, or <c>null</c> when not authenticated.</summary>
     public FtpConnectionSettings? Settings { get; private set; }
+
+    /// <inheritdoc />
     public event Action? AuthChanged;
 
+    /// <inheritdoc />
     public async Task<AuthResult> AuthenticateAsync(AuthRequest request, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(request.Host))
@@ -29,7 +44,8 @@ public sealed class FtpProviderAuth : IStorageProviderAuth
         try
         {
             await conn.ConnectAsync(ct);
-            await conn.DisconnectAsync(ct);
+            // Disconnect with a non-cancellable token so a cancelled request still closes cleanly.
+            await conn.DisconnectAsync(CancellationToken.None);
         }
         catch (Exception ex)
         {
@@ -46,6 +62,7 @@ public sealed class FtpProviderAuth : IStorageProviderAuth
         return new AuthResult(true, null, Account);
     }
 
+    /// <inheritdoc />
     public Task SignOutAsync(CancellationToken ct = default)
     {
         Settings = null;

--- a/src/Atypical.VirtualFileSystem.Ftp/FtpProviderAuth.cs
+++ b/src/Atypical.VirtualFileSystem.Ftp/FtpProviderAuth.cs
@@ -1,0 +1,56 @@
+namespace Atypical.VirtualFileSystem.Ftp;
+
+public sealed class FtpProviderAuth : IStorageProviderAuth
+{
+    private readonly Func<FtpConnectionSettings, IFtpConnection> _factory;
+
+    public FtpProviderAuth(Func<FtpConnectionSettings, IFtpConnection> factory) => _factory = factory;
+
+    public AuthKind Kind => AuthKind.Credentials;
+    public bool IsAuthenticated => Settings is not null;
+    public ProviderAccountInfo? Account { get; private set; }
+    public FtpConnectionSettings? Settings { get; private set; }
+    public event Action? AuthChanged;
+
+    public async Task<AuthResult> AuthenticateAsync(AuthRequest request, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.Host))
+            return new AuthResult(false, "Host is required.", null);
+
+        var settings = new FtpConnectionSettings
+        {
+            Host = request.Host,
+            Port = request.Port == 0 ? 21 : request.Port,
+            Username = request.Username,
+            Password = request.Password,
+            UseTls = request.UseTls
+        };
+        var conn = _factory(settings);
+        try
+        {
+            await conn.ConnectAsync(ct);
+            await conn.DisconnectAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            return new AuthResult(false, $"Connection failed: {ex.Message}", null);
+        }
+        finally
+        {
+            if (conn is IAsyncDisposable d) await d.DisposeAsync();
+        }
+
+        Settings = settings;
+        Account = new ProviderAccountInfo { DisplayName = $"{request.Username}@{request.Host}" };
+        AuthChanged?.Invoke();
+        return new AuthResult(true, null, Account);
+    }
+
+    public Task SignOutAsync(CancellationToken ct = default)
+    {
+        Settings = null;
+        Account = null;
+        AuthChanged?.Invoke();
+        return Task.CompletedTask;
+    }
+}

--- a/src/Atypical.VirtualFileSystem.Ftp/FtpRemoteItem.cs
+++ b/src/Atypical.VirtualFileSystem.Ftp/FtpRemoteItem.cs
@@ -1,0 +1,8 @@
+namespace Atypical.VirtualFileSystem.Ftp;
+
+/// <summary>A single entry returned by an FTP directory listing.</summary>
+/// <param name="FullPath">The absolute remote path of the entry.</param>
+/// <param name="IsDirectory">Whether the entry is a directory.</param>
+/// <param name="SizeBytes">The size of the entry in bytes (0 for directories).</param>
+/// <param name="LastModifiedUtc">The last-modified timestamp, in UTC.</param>
+public sealed record FtpRemoteItem(string FullPath, bool IsDirectory, long SizeBytes, DateTimeOffset LastModifiedUtc);

--- a/src/Atypical.VirtualFileSystem.Ftp/FtpStorageProvider.cs
+++ b/src/Atypical.VirtualFileSystem.Ftp/FtpStorageProvider.cs
@@ -2,28 +2,37 @@ using System.Diagnostics;
 
 namespace Atypical.VirtualFileSystem.Ftp;
 
+/// <summary>
+/// A read+write storage provider over FTP/FTPS (backed by FluentFTP through the <see cref="IFtpConnection"/> seam).
+/// </summary>
 public sealed class FtpStorageProvider : IStorageProvider
 {
     private readonly Func<FtpConnectionSettings, IFtpConnection> _connectionFactory;
     private readonly FtpProviderAuth _auth;
 
+    /// <summary>Creates the provider using the given connection factory.</summary>
     public FtpStorageProvider(Func<FtpConnectionSettings, IFtpConnection> connectionFactory)
     {
         _connectionFactory = connectionFactory;
         _auth = new FtpProviderAuth(connectionFactory);
     }
 
+    /// <inheritdoc />
     public string Id => "ftp";
+
+    /// <inheritdoc />
     public string DisplayName => "FTP";
+
+    /// <inheritdoc />
     public IStorageProviderAuth Auth => _auth;
 
+    /// <inheritdoc />
     public ProviderCapabilities Capabilities => new() { AuthKind = AuthKind.Credentials };
 
+    /// <inheritdoc />
     public async Task<ProviderLoadResult> ImportAsync(IVirtualFileSystem vfs, ProviderLoadOptions options, CancellationToken ct = default)
     {
-        // Use authenticated settings if available; fall back to an empty placeholder so the factory
-        // (which may be a test-double ignoring its argument) still receives a non-null value.
-        var settings = _auth.Settings ?? new FtpConnectionSettings { Host = string.Empty };
+        var settings = _auth.Settings ?? throw new InvalidOperationException("FTP provider is not authenticated.");
         var root = string.IsNullOrWhiteSpace(options.RemoteRoot) ? "/" : options.RemoteRoot!;
         var sw = Stopwatch.StartNew();
         var skipped = new List<ProviderSkippedFile>();
@@ -47,6 +56,12 @@ public sealed class FtpStorageProvider : IStorageProvider
                     {
                         queue.Enqueue(item.FullPath);
                         dirs++;
+
+                        // Materialize the directory node so empty directories appear in the VFS.
+                        var dirPath = ToVfsPath(item.FullPath);
+                        if (!vfs.Index.ContainsKey(new VFSDirectoryPath(dirPath)))
+                            vfs.CreateDirectory(dirPath);
+
                         continue;
                     }
 
@@ -79,8 +94,7 @@ public sealed class FtpStorageProvider : IStorageProvider
         }
         finally
         {
-            await conn.DisconnectAsync(ct);
-            if (conn is IAsyncDisposable d) await d.DisposeAsync();
+            await CloseAsync(conn);
         }
 
         sw.Stop();
@@ -95,6 +109,7 @@ public sealed class FtpStorageProvider : IStorageProvider
         };
     }
 
+    /// <inheritdoc />
     public async Task<ProviderFileContent> ReadFileAsync(string remotePath, CancellationToken ct = default)
     {
         var settings = _auth.Settings ?? throw new InvalidOperationException("FTP provider is not authenticated.");
@@ -107,11 +122,11 @@ public sealed class FtpStorageProvider : IStorageProvider
         }
         finally
         {
-            await conn.DisconnectAsync(ct);
-            if (conn is IAsyncDisposable d) await d.DisposeAsync();
+            await CloseAsync(conn);
         }
     }
 
+    /// <inheritdoc />
     public async Task<ProviderWriteResult> WriteChangesAsync(IReadOnlyList<ProviderFileChange> changes, CommitContext context, CancellationToken ct = default)
     {
         var settings = _auth.Settings ?? throw new InvalidOperationException("FTP provider is not authenticated.");
@@ -140,8 +155,7 @@ public sealed class FtpStorageProvider : IStorageProvider
         }
         finally
         {
-            await conn.DisconnectAsync(ct);
-            if (conn is IAsyncDisposable d) await d.DisposeAsync();
+            await CloseAsync(conn);
         }
 
         return new ProviderWriteResult
@@ -151,8 +165,30 @@ public sealed class FtpStorageProvider : IStorageProvider
         };
     }
 
+    /// <inheritdoc />
     public Task<ProviderAccountInfo> GetAccountInfoAsync(CancellationToken ct = default)
         => Task.FromResult(_auth.Account ?? ProviderAccountInfo.Anonymous);
+
+    /// <summary>
+    /// Disconnects (best-effort, non-cancellable) and always disposes the connection so the
+    /// underlying socket is never leaked, even if disconnect throws or the operation was cancelled.
+    /// </summary>
+    private static async Task CloseAsync(IFtpConnection conn)
+    {
+        try
+        {
+            await conn.DisconnectAsync(CancellationToken.None);
+        }
+        catch
+        {
+            // Ignore disconnect failures; disposal below still releases the socket.
+        }
+        finally
+        {
+            if (conn is IAsyncDisposable d)
+                await d.DisposeAsync();
+        }
+    }
 
     // Map an absolute remote path (e.g. "/data/sub/a.txt") to a VFS-relative path ("data/sub/a.txt").
     private static string ToVfsPath(string remotePath) => remotePath.TrimStart('/');

--- a/src/Atypical.VirtualFileSystem.Ftp/FtpStorageProvider.cs
+++ b/src/Atypical.VirtualFileSystem.Ftp/FtpStorageProvider.cs
@@ -1,0 +1,165 @@
+using System.Diagnostics;
+
+namespace Atypical.VirtualFileSystem.Ftp;
+
+public sealed class FtpStorageProvider : IStorageProvider
+{
+    private readonly Func<FtpConnectionSettings, IFtpConnection> _connectionFactory;
+    private readonly FtpProviderAuth _auth;
+
+    public FtpStorageProvider(Func<FtpConnectionSettings, IFtpConnection> connectionFactory)
+    {
+        _connectionFactory = connectionFactory;
+        _auth = new FtpProviderAuth(connectionFactory);
+    }
+
+    public string Id => "ftp";
+    public string DisplayName => "FTP";
+    public IStorageProviderAuth Auth => _auth;
+
+    public ProviderCapabilities Capabilities => new() { AuthKind = AuthKind.Credentials };
+
+    public async Task<ProviderLoadResult> ImportAsync(IVirtualFileSystem vfs, ProviderLoadOptions options, CancellationToken ct = default)
+    {
+        // Use authenticated settings if available; fall back to an empty placeholder so the factory
+        // (which may be a test-double ignoring its argument) still receives a non-null value.
+        var settings = _auth.Settings ?? new FtpConnectionSettings { Host = string.Empty };
+        var root = string.IsNullOrWhiteSpace(options.RemoteRoot) ? "/" : options.RemoteRoot!;
+        var sw = Stopwatch.StartNew();
+        var skipped = new List<ProviderSkippedFile>();
+        int files = 0, dirs = 0;
+        long bytes = 0;
+
+        var conn = _connectionFactory(settings);
+        try
+        {
+            await conn.ConnectAsync(ct);
+
+            var queue = new Queue<string>();
+            queue.Enqueue(root);
+            while (queue.Count > 0)
+            {
+                ct.ThrowIfCancellationRequested();
+                var current = queue.Dequeue();
+                foreach (var item in await conn.ListAsync(current, ct))
+                {
+                    if (item.IsDirectory)
+                    {
+                        queue.Enqueue(item.FullPath);
+                        dirs++;
+                        continue;
+                    }
+
+                    if (item.SizeBytes > options.MaxFileSizeBytes)
+                    {
+                        skipped.Add(new(item.FullPath, ProviderSkipReason.TooLarge, item.SizeBytes, null));
+                        continue;
+                    }
+
+                    try
+                    {
+                        var data = await conn.DownloadAsync(item.FullPath, ct);
+                        var vfsPath = ToVfsPath(item.FullPath);
+                        var versionToken = $"{item.LastModifiedUtc:O}:{item.SizeBytes}";
+                        if (IsBinary(item.FullPath))
+                            vfs.CreateBinaryFileWithDirectories(vfsPath, data);
+                        else
+                            vfs.CreateFileWithDirectories(vfsPath, System.Text.Encoding.UTF8.GetString(data));
+                        options.MetadataCallback?.Invoke(vfsPath, item.FullPath, versionToken);
+                        files++;
+                        bytes += data.Length;
+                        options.ProgressCallback?.Invoke(files, item.FullPath);
+                    }
+                    catch (Exception ex)
+                    {
+                        skipped.Add(new(item.FullPath, ProviderSkipReason.LoadError, item.SizeBytes, ex.Message));
+                    }
+                }
+            }
+        }
+        finally
+        {
+            await conn.DisconnectAsync(ct);
+            if (conn is IAsyncDisposable d) await d.DisposeAsync();
+        }
+
+        sw.Stop();
+        return new ProviderLoadResult
+        {
+            RemoteRoot = root,
+            FilesLoaded = files,
+            DirectoriesCreated = dirs,
+            TotalBytes = bytes,
+            Skipped = skipped,
+            Duration = sw.Elapsed
+        };
+    }
+
+    public async Task<ProviderFileContent> ReadFileAsync(string remotePath, CancellationToken ct = default)
+    {
+        var settings = _auth.Settings ?? throw new InvalidOperationException("FTP provider is not authenticated.");
+        var conn = _connectionFactory(settings);
+        try
+        {
+            await conn.ConnectAsync(ct);
+            var data = await conn.DownloadAsync(remotePath, ct);
+            return new ProviderFileContent(data, VersionToken: string.Empty, IsBinary: IsBinary(remotePath));
+        }
+        finally
+        {
+            await conn.DisconnectAsync(ct);
+            if (conn is IAsyncDisposable d) await d.DisposeAsync();
+        }
+    }
+
+    public async Task<ProviderWriteResult> WriteChangesAsync(IReadOnlyList<ProviderFileChange> changes, CommitContext context, CancellationToken ct = default)
+    {
+        var settings = _auth.Settings ?? throw new InvalidOperationException("FTP provider is not authenticated.");
+        var fileResults = new List<ProviderFileWriteResult>();
+
+        var conn = _connectionFactory(settings);
+        try
+        {
+            await conn.ConnectAsync(ct);
+            foreach (var change in changes)
+            {
+                ct.ThrowIfCancellationRequested();
+                try
+                {
+                    if (change.Kind == ChangeKind.Delete)
+                        await conn.DeleteFileAsync(change.RemotePath, ct);
+                    else
+                        await conn.UploadAsync(change.RemotePath, change.Content ?? [], ct);
+                    fileResults.Add(new(change.RemotePath, true, null));
+                }
+                catch (Exception ex)
+                {
+                    fileResults.Add(new(change.RemotePath, false, ex.Message));
+                }
+            }
+        }
+        finally
+        {
+            await conn.DisconnectAsync(ct);
+            if (conn is IAsyncDisposable d) await d.DisposeAsync();
+        }
+
+        return new ProviderWriteResult
+        {
+            Success = fileResults.All(r => r.Success),
+            FileResults = fileResults
+        };
+    }
+
+    public Task<ProviderAccountInfo> GetAccountInfoAsync(CancellationToken ct = default)
+        => Task.FromResult(_auth.Account ?? ProviderAccountInfo.Anonymous);
+
+    // Map an absolute remote path (e.g. "/data/sub/a.txt") to a VFS-relative path ("data/sub/a.txt").
+    private static string ToVfsPath(string remotePath) => remotePath.TrimStart('/');
+
+    private static bool IsBinary(string path)
+    {
+        var ext = Path.GetExtension(path).ToLowerInvariant();
+        return ext is ".png" or ".jpg" or ".jpeg" or ".gif" or ".pdf" or ".zip" or ".exe" or ".dll" or ".bin";
+    }
+}

--- a/src/Atypical.VirtualFileSystem.Ftp/GlobalUsings.cs
+++ b/src/Atypical.VirtualFileSystem.Ftp/GlobalUsings.cs
@@ -1,0 +1,3 @@
+global using Atypical.VirtualFileSystem.Core;
+global using Atypical.VirtualFileSystem.Core.Contracts;
+global using Atypical.VirtualFileSystem.Providers.Abstractions;

--- a/src/Atypical.VirtualFileSystem.Ftp/GlobalUsings.cs
+++ b/src/Atypical.VirtualFileSystem.Ftp/GlobalUsings.cs
@@ -1,3 +1,4 @@
 global using Atypical.VirtualFileSystem.Core;
 global using Atypical.VirtualFileSystem.Core.Contracts;
+global using Atypical.VirtualFileSystem.Core.Extensions;
 global using Atypical.VirtualFileSystem.Providers.Abstractions;

--- a/src/Atypical.VirtualFileSystem.Ftp/IFtpConnection.cs
+++ b/src/Atypical.VirtualFileSystem.Ftp/IFtpConnection.cs
@@ -1,14 +1,23 @@
 namespace Atypical.VirtualFileSystem.Ftp;
 
-public sealed record FtpRemoteItem(string FullPath, bool IsDirectory, long SizeBytes, DateTime LastModifiedUtc);
-
-/// <summary>Minimal async FTP surface used by FtpStorageProvider; backed by FluentFTP in production.</summary>
+/// <summary>Minimal async FTP surface used by <see cref="FtpStorageProvider"/>; backed by FluentFTP in production.</summary>
 public interface IFtpConnection
 {
+    /// <summary>Opens the FTP control connection.</summary>
     Task ConnectAsync(CancellationToken ct);
+
+    /// <summary>Closes the FTP control connection.</summary>
     Task DisconnectAsync(CancellationToken ct);
+
+    /// <summary>Lists the immediate children (files and directories) of the given remote directory.</summary>
     Task<IReadOnlyList<FtpRemoteItem>> ListAsync(string remoteDir, CancellationToken ct);
+
+    /// <summary>Downloads the full contents of a remote file.</summary>
     Task<byte[]> DownloadAsync(string remotePath, CancellationToken ct);
+
+    /// <summary>Uploads (overwriting) the given content to a remote path, creating parent directories as needed.</summary>
     Task UploadAsync(string remotePath, byte[] content, CancellationToken ct);
+
+    /// <summary>Deletes a remote file.</summary>
     Task DeleteFileAsync(string remotePath, CancellationToken ct);
 }

--- a/src/Atypical.VirtualFileSystem.Ftp/IFtpConnection.cs
+++ b/src/Atypical.VirtualFileSystem.Ftp/IFtpConnection.cs
@@ -1,0 +1,14 @@
+namespace Atypical.VirtualFileSystem.Ftp;
+
+public sealed record FtpRemoteItem(string FullPath, bool IsDirectory, long SizeBytes, DateTime LastModifiedUtc);
+
+/// <summary>Minimal async FTP surface used by FtpStorageProvider; backed by FluentFTP in production.</summary>
+public interface IFtpConnection
+{
+    Task ConnectAsync(CancellationToken ct);
+    Task DisconnectAsync(CancellationToken ct);
+    Task<IReadOnlyList<FtpRemoteItem>> ListAsync(string remoteDir, CancellationToken ct);
+    Task<byte[]> DownloadAsync(string remotePath, CancellationToken ct);
+    Task UploadAsync(string remotePath, byte[] content, CancellationToken ct);
+    Task DeleteFileAsync(string remotePath, CancellationToken ct);
+}

--- a/src/Atypical.VirtualFileSystem.Ftp/IFtpConnectionFactory.cs
+++ b/src/Atypical.VirtualFileSystem.Ftp/IFtpConnectionFactory.cs
@@ -1,0 +1,8 @@
+namespace Atypical.VirtualFileSystem.Ftp;
+
+/// <summary>Creates <see cref="IFtpConnection"/> instances from connection settings.</summary>
+public interface IFtpConnectionFactory
+{
+    /// <summary>Creates a new connection for the given settings.</summary>
+    IFtpConnection Create(FtpConnectionSettings settings);
+}

--- a/src/Atypical.VirtualFileSystem.Ftp/ServiceCollectionExtensions.cs
+++ b/src/Atypical.VirtualFileSystem.Ftp/ServiceCollectionExtensions.cs
@@ -2,8 +2,14 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Atypical.VirtualFileSystem.Ftp;
 
+/// <summary>
+/// Extension methods for registering the FTP storage provider in the dependency injection container.
+/// </summary>
 public static class ServiceCollectionExtensions
 {
+    /// <summary>Registers the FTP connection factory and <see cref="FtpStorageProvider"/> as scoped services.</summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection.</returns>
     public static IServiceCollection AddVirtualFileSystemFtp(this IServiceCollection services)
     {
         services.AddScoped<IFtpConnectionFactory, FluentFtpConnectionFactory>();
@@ -14,14 +20,4 @@ public static class ServiceCollectionExtensions
         });
         return services;
     }
-}
-
-public interface IFtpConnectionFactory
-{
-    IFtpConnection Create(FtpConnectionSettings settings);
-}
-
-public sealed class FluentFtpConnectionFactory : IFtpConnectionFactory
-{
-    public IFtpConnection Create(FtpConnectionSettings settings) => new FluentFtpConnection(settings);
 }

--- a/src/Atypical.VirtualFileSystem.Ftp/ServiceCollectionExtensions.cs
+++ b/src/Atypical.VirtualFileSystem.Ftp/ServiceCollectionExtensions.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Atypical.VirtualFileSystem.Ftp;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddVirtualFileSystemFtp(this IServiceCollection services)
+    {
+        services.AddScoped<IFtpConnectionFactory, FluentFtpConnectionFactory>();
+        services.AddScoped<FtpStorageProvider>(sp =>
+        {
+            var factory = sp.GetRequiredService<IFtpConnectionFactory>();
+            return new FtpStorageProvider(settings => factory.Create(settings));
+        });
+        return services;
+    }
+}
+
+public interface IFtpConnectionFactory
+{
+    IFtpConnection Create(FtpConnectionSettings settings);
+}
+
+public sealed class FluentFtpConnectionFactory : IFtpConnectionFactory
+{
+    public IFtpConnection Create(FtpConnectionSettings settings) => new FluentFtpConnection(settings);
+}

--- a/src/Atypical.VirtualFileSystem.GitHub/Atypical.VirtualFileSystem.GitHub.csproj
+++ b/src/Atypical.VirtualFileSystem.GitHub/Atypical.VirtualFileSystem.GitHub.csproj
@@ -20,6 +20,7 @@
     <!-- Project references -->
     <ItemGroup>
         <ProjectReference Include="..\Atypical.VirtualFileSystem.Core\Atypical.VirtualFileSystem.Core.csproj" />
+        <ProjectReference Include="..\Atypical.VirtualFileSystem.Providers.Abstractions\Atypical.VirtualFileSystem.Providers.Abstractions.csproj" />
     </ItemGroup>
 
     <!-- NuGet metadata -->

--- a/src/Atypical.VirtualFileSystem.GitHub/Providers/GitHubProviderAdapters.cs
+++ b/src/Atypical.VirtualFileSystem.GitHub/Providers/GitHubProviderAdapters.cs
@@ -18,7 +18,10 @@ public static class GitHubProviderAdapters
     public static GitHubLoaderOptions ToGitHubLoaderOptions(ProviderLoadOptions o, string? accessToken)
         => new(
             AccessToken: accessToken,
-            TargetPath: o.RemoteRoot ?? "/",
+            // RemoteRoot is the REMOTE sub-path to import FROM, so it maps to the loader's
+            // SubPath (a remote filter). TargetPath is the VFS DESTINATION root and is left
+            // at the loader's default ("/"), preserving the original load layout.
+            SubPath: o.RemoteRoot,
             MaxFileSize: o.MaxFileSizeBytes,
             Strategy: o.Strategy switch
             {

--- a/src/Atypical.VirtualFileSystem.GitHub/Providers/GitHubProviderAdapters.cs
+++ b/src/Atypical.VirtualFileSystem.GitHub/Providers/GitHubProviderAdapters.cs
@@ -35,6 +35,10 @@ public static class GitHubProviderAdapters
             ExcludeExtensions: o.BlockedExtensions is null
                 ? null
                 : new HashSet<string>(o.BlockedExtensions, StringComparer.OrdinalIgnoreCase),
+            // NOTE: GlobPattern is not forwarded this milestone (GitHub exposes only exclude patterns
+            // via ExcludePatterns; include-glob support is a follow-on). The neutral GlobPattern is an
+            // include-style filter, so mapping it onto the exclude-style ExcludePatterns would invert
+            // its meaning. Dropping it is intentional rather than mismapping it.
             MetadataCallback: o.MetadataCallback,
             ProgressCallback: o.ProgressCallback is null
                 ? null
@@ -44,15 +48,22 @@ public static class GitHubProviderAdapters
     /// <summary>
     /// Maps a <see cref="GitHubLoadResult"/> to a neutral <see cref="ProviderLoadResult"/>.
     /// </summary>
-    public static ProviderLoadResult ToProviderLoadResult(GitHubLoadResult r)
+    /// <param name="r">The GitHub load result.</param>
+    /// <param name="requestedRemoteRoot">
+    /// The originally requested remote root (e.g. <c>owner/repo[/subpath]</c>) echoed back on the
+    /// result. The GitHub result only carries the VFS <c>TargetPath</c> (usually <c>/</c>), so the
+    /// neutral <see cref="ProviderLoadResult.RemoteRoot"/> is supplied by the caller instead.
+    /// </param>
+    public static ProviderLoadResult ToProviderLoadResult(GitHubLoadResult r, string requestedRemoteRoot)
         => new()
         {
-            RemoteRoot = r.TargetPath ?? string.Empty,
+            RemoteRoot = requestedRemoteRoot,
             FilesLoaded = r.FilesLoaded,
             DirectoriesCreated = r.DirectoriesCreated,
             TotalBytes = r.TotalBytesLoaded,
             Duration = r.LoadDuration,
             Skipped = r.SkippedFiles
+                // Size is unknown for some skip reasons; the neutral record uses 0 as 'unknown'.
                 .Select(s => new ProviderSkippedFile(s.Path, ToSkipReason(s.Reason), s.Size ?? 0, s.ErrorMessage))
                 .ToList(),
         };
@@ -60,6 +71,8 @@ public static class GitHubProviderAdapters
     private static ProviderSkipReason ToSkipReason(SkipReason r) => r switch
     {
         SkipReason.TooLarge => ProviderSkipReason.TooLarge,
+        // BinaryExcluded / ExtensionNotIncluded / ExtensionExcluded intentionally collapse to
+        // BlockedExtension: the neutral enum is coarser and does not distinguish those reasons.
         SkipReason.ExtensionNotIncluded => ProviderSkipReason.BlockedExtension,
         SkipReason.ExtensionExcluded => ProviderSkipReason.BlockedExtension,
         SkipReason.BinaryExcluded => ProviderSkipReason.BlockedExtension,

--- a/src/Atypical.VirtualFileSystem.GitHub/Providers/GitHubProviderAdapters.cs
+++ b/src/Atypical.VirtualFileSystem.GitHub/Providers/GitHubProviderAdapters.cs
@@ -1,0 +1,66 @@
+// Copyright (c) 2022-2025, Atypical Consulting SRL
+// All rights reserved... but seriously, we're open to sharing if you ask nicely!
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+using Atypical.VirtualFileSystem.Providers.Abstractions;
+
+namespace Atypical.VirtualFileSystem.GitHub.Providers;
+
+public static class GitHubProviderAdapters
+{
+    /// <summary>
+    /// Maps a neutral <see cref="ProviderLoadOptions"/> to a <see cref="GitHubLoaderOptions"/>.
+    /// </summary>
+    /// <param name="o">The neutral provider load options.</param>
+    /// <param name="accessToken">The GitHub personal access token.</param>
+    public static GitHubLoaderOptions ToGitHubLoaderOptions(ProviderLoadOptions o, string? accessToken)
+        => new(
+            AccessToken: accessToken,
+            TargetPath: o.RemoteRoot ?? "/",
+            MaxFileSize: o.MaxFileSizeBytes,
+            Strategy: o.Strategy switch
+            {
+                ProviderLoadingStrategy.Lazy => GitHubLoadingStrategy.Lazy,
+                ProviderLoadingStrategy.MetadataOnly => GitHubLoadingStrategy.MetadataOnly,
+                _ => GitHubLoadingStrategy.Eager
+            },
+            IncludeExtensions: o.AllowedExtensions is null
+                ? null
+                : new HashSet<string>(o.AllowedExtensions, StringComparer.OrdinalIgnoreCase),
+            ExcludeExtensions: o.BlockedExtensions is null
+                ? null
+                : new HashSet<string>(o.BlockedExtensions, StringComparer.OrdinalIgnoreCase),
+            MetadataCallback: o.MetadataCallback,
+            ProgressCallback: o.ProgressCallback is null
+                ? null
+                : (current, total, path) => o.ProgressCallback(current, path)
+        );
+
+    /// <summary>
+    /// Maps a <see cref="GitHubLoadResult"/> to a neutral <see cref="ProviderLoadResult"/>.
+    /// </summary>
+    public static ProviderLoadResult ToProviderLoadResult(GitHubLoadResult r)
+        => new()
+        {
+            RemoteRoot = r.TargetPath ?? string.Empty,
+            FilesLoaded = r.FilesLoaded,
+            DirectoriesCreated = r.DirectoriesCreated,
+            TotalBytes = r.TotalBytesLoaded,
+            Duration = r.LoadDuration,
+            Skipped = r.SkippedFiles
+                .Select(s => new ProviderSkippedFile(s.Path, ToSkipReason(s.Reason), s.Size ?? 0, s.ErrorMessage))
+                .ToList(),
+        };
+
+    private static ProviderSkipReason ToSkipReason(SkipReason r) => r switch
+    {
+        SkipReason.TooLarge => ProviderSkipReason.TooLarge,
+        SkipReason.ExtensionNotIncluded => ProviderSkipReason.BlockedExtension,
+        SkipReason.ExtensionExcluded => ProviderSkipReason.BlockedExtension,
+        SkipReason.BinaryExcluded => ProviderSkipReason.BlockedExtension,
+        SkipReason.PatternExcluded => ProviderSkipReason.NotMatchingGlob,
+        _ => ProviderSkipReason.LoadError
+    };
+}

--- a/src/Atypical.VirtualFileSystem.GitHub/Providers/GitHubProviderAuth.cs
+++ b/src/Atypical.VirtualFileSystem.GitHub/Providers/GitHubProviderAuth.cs
@@ -1,0 +1,83 @@
+// Copyright (c) 2022-2025, Atypical Consulting SRL
+// All rights reserved... but seriously, we're open to sharing if you ask nicely!
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+using Atypical.VirtualFileSystem.Providers.Abstractions;
+using Octokit;
+
+namespace Atypical.VirtualFileSystem.GitHub.Providers;
+
+/// <summary>
+/// Handles token-based authentication for the GitHub storage provider.
+/// Validates the personal access token against the GitHub API and populates
+/// <see cref="Account"/> with the authenticated user's identity and rate-limit info.
+/// </summary>
+public sealed class GitHubProviderAuth : IStorageProviderAuth
+{
+    private const string ProductHeader = "Atypical.VirtualFileSystem.GitHub";
+    private string? _token;
+
+    /// <inheritdoc />
+    public AuthKind Kind => AuthKind.Token;
+
+    /// <inheritdoc />
+    public bool IsAuthenticated => !string.IsNullOrEmpty(_token) && Account is not null;
+
+    /// <inheritdoc />
+    public ProviderAccountInfo? Account { get; private set; }
+
+    /// <inheritdoc />
+    public event Action? AuthChanged;
+
+    /// <summary>
+    /// Returns the current access token, or <see langword="null"/> when not authenticated.
+    /// </summary>
+    public string? Token => _token;
+
+    /// <inheritdoc />
+    public async Task<AuthResult> AuthenticateAsync(AuthRequest request, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.Token))
+            return new AuthResult(false, "Token cannot be empty.", null);
+
+        try
+        {
+            var client = new GitHubClient(new Octokit.ProductHeaderValue(ProductHeader))
+            {
+                Credentials = new Credentials(request.Token)
+            };
+            var user = await client.User.Current();
+            var limits = await client.RateLimit.GetRateLimits();
+
+            _token = request.Token;
+            Account = new ProviderAccountInfo
+            {
+                DisplayName = user.Login,
+                RateLimitRemaining = limits.Resources.Core.Remaining,
+                RateLimitTotal = limits.Resources.Core.Limit,
+                RateLimitReset = limits.Resources.Core.Reset
+            };
+            AuthChanged?.Invoke();
+            return new AuthResult(true, null, Account);
+        }
+        catch (AuthorizationException)
+        {
+            return new AuthResult(false, "Invalid token.", null);
+        }
+        catch (ApiException ex)
+        {
+            return new AuthResult(false, $"GitHub API error: {ex.Message}", null);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task SignOutAsync(CancellationToken cancellationToken = default)
+    {
+        _token = null;
+        Account = null;
+        AuthChanged?.Invoke();
+        return Task.CompletedTask;
+    }
+}

--- a/src/Atypical.VirtualFileSystem.GitHub/Providers/GitHubStorageProvider.cs
+++ b/src/Atypical.VirtualFileSystem.GitHub/Providers/GitHubStorageProvider.cs
@@ -76,7 +76,7 @@ public sealed class GitHubStorageProvider : IStorageProvider
             options with { RemoteRoot = subPath },
             _auth.Token);
         var result = await _loader.LoadRepositoryAsync(vfs, owner, repo, ghOptions, cancellationToken);
-        return GitHubProviderAdapters.ToProviderLoadResult(result);
+        return GitHubProviderAdapters.ToProviderLoadResult(result, options.RemoteRoot ?? string.Empty);
     }
 
     /// <inheritdoc />

--- a/src/Atypical.VirtualFileSystem.GitHub/Providers/GitHubStorageProvider.cs
+++ b/src/Atypical.VirtualFileSystem.GitHub/Providers/GitHubStorageProvider.cs
@@ -1,0 +1,117 @@
+// Copyright (c) 2022-2025, Atypical Consulting SRL
+// All rights reserved... but seriously, we're open to sharing if you ask nicely!
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+using Atypical.VirtualFileSystem.Providers.Abstractions;
+
+namespace Atypical.VirtualFileSystem.GitHub.Providers;
+
+/// <summary>
+/// An <see cref="IStorageProvider"/> that wraps the existing <see cref="IGitHubRepositoryLoader"/>
+/// and <see cref="IGitHubWriteService"/> behind the neutral provider abstraction.
+/// All import logic is delegated to the loader; no loader/write-service logic is duplicated here.
+/// </summary>
+/// <remarks>
+/// Design note: GitHub's write orchestration (fork→branch→commit→PR) already lives in the
+/// Blazor <c>GitHubPendingChangesService</c>. To avoid duplicating it, the provider's
+/// <see cref="WriteChangesAsync"/> throws for now and the app's <c>StoragePendingChangesService</c>
+/// calls the GitHub write service directly when the active provider is GitHub.
+/// This is a deliberate, documented seam — revisit when extracting writes fully in a later milestone.
+/// </remarks>
+public sealed class GitHubStorageProvider : IStorageProvider
+{
+    private readonly IGitHubRepositoryLoader _loader;
+    private readonly IGitHubWriteService _writeService;
+    private readonly GitHubProviderAuth _auth;
+
+    /// <summary>
+    /// Initialises a new <see cref="GitHubStorageProvider"/>.
+    /// </summary>
+    /// <param name="loader">The repository loader.</param>
+    /// <param name="writeService">The write service (used for future write orchestration).</param>
+    /// <param name="auth">The token-based auth handler.</param>
+    public GitHubStorageProvider(IGitHubRepositoryLoader loader, IGitHubWriteService writeService, GitHubProviderAuth auth)
+    {
+        _loader = loader;
+        _writeService = writeService;
+        _auth = auth;
+    }
+
+    /// <inheritdoc />
+    public string Id => "github";
+
+    /// <inheritdoc />
+    public string DisplayName => "GitHub";
+
+    /// <inheritdoc />
+    public IStorageProviderAuth Auth => _auth;
+
+    /// <inheritdoc />
+    public ProviderCapabilities Capabilities => new()
+    {
+        SupportsBranches = true,
+        SupportsPullRequests = true,
+        SupportsFork = true,
+        SupportsAtomicMultiFileCommit = true,
+        SupportsVersioning = true,
+        AuthKind = AuthKind.Token
+    };
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// <paramref name="options"/>.<see cref="ProviderLoadOptions.RemoteRoot"/> must be in the form
+    /// <c>owner/repo</c> or <c>owner/repo/subpath</c>. The sub-path (if any) is forwarded to the
+    /// loader as the <see cref="GitHubLoaderOptions.SubPath"/> filter so that only files under that
+    /// path are imported. The VFS target root defaults to <c>/</c>.
+    /// </remarks>
+    public async Task<ProviderLoadResult> ImportAsync(
+        IVirtualFileSystem vfs,
+        ProviderLoadOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        var (owner, repo, subPath) = ParseRemoteRoot(options.RemoteRoot);
+        var ghOptions = GitHubProviderAdapters.ToGitHubLoaderOptions(
+            options with { RemoteRoot = subPath },
+            _auth.Token);
+        var result = await _loader.LoadRepositoryAsync(vfs, owner, repo, ghOptions, cancellationToken);
+        return GitHubProviderAdapters.ToProviderLoadResult(result);
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="NotSupportedException">
+    /// Always thrown — single-file reads are performed during import for GitHub and are not
+    /// exposed through the provider surface in the current milestone.
+    /// </exception>
+    public Task<ProviderFileContent> ReadFileAsync(string remotePath, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException(
+            "Single-file read is performed during import for GitHub; not used by the current UI.");
+
+    /// <inheritdoc />
+    /// <exception cref="NotSupportedException">
+    /// Always thrown — GitHub writes are orchestrated by <c>StoragePendingChangesService</c> in Task 4.x.
+    /// </exception>
+    public Task<ProviderWriteResult> WriteChangesAsync(
+        IReadOnlyList<ProviderFileChange> changes,
+        CommitContext context,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException(
+            "GitHub writes are orchestrated by StoragePendingChangesService in Task 4.x.");
+
+    /// <inheritdoc />
+    public Task<ProviderAccountInfo> GetAccountInfoAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(_auth.Account ?? ProviderAccountInfo.Anonymous);
+
+    /// <summary>
+    /// Parses a GitHub remote root string of the form <c>owner/repo[/subpath]</c>.
+    /// </summary>
+    private static (string owner, string repo, string? subPath) ParseRemoteRoot(string? remoteRoot)
+    {
+        var parts = (remoteRoot ?? string.Empty).Trim('/').Split('/', 3);
+        if (parts.Length < 2 || string.IsNullOrEmpty(parts[0]) || string.IsNullOrEmpty(parts[1]))
+            throw new ArgumentException(
+                "GitHub RemoteRoot must be 'owner/repo[/subpath]'.", nameof(remoteRoot));
+        return (parts[0], parts[1], parts.Length == 3 ? parts[2] : null);
+    }
+}

--- a/src/Atypical.VirtualFileSystem.Providers.Abstractions/Atypical.VirtualFileSystem.Providers.Abstractions.csproj
+++ b/src/Atypical.VirtualFileSystem.Providers.Abstractions/Atypical.VirtualFileSystem.Providers.Abstractions.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>Atypical.VirtualFileSystem.Providers.Abstractions</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Atypical.VirtualFileSystem.Core\Atypical.VirtualFileSystem.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Atypical.VirtualFileSystem.Providers.Abstractions/AuthKind.cs
+++ b/src/Atypical.VirtualFileSystem.Providers.Abstractions/AuthKind.cs
@@ -1,0 +1,12 @@
+namespace Atypical.VirtualFileSystem.Providers.Abstractions;
+
+/// <summary>How a provider authenticates.</summary>
+public enum AuthKind
+{
+    /// <summary>A single bearer token / PAT.</summary>
+    Token,
+    /// <summary>Host + username/password style credentials.</summary>
+    Credentials,
+    /// <summary>Interactive OAuth (reserved for future providers).</summary>
+    OAuth
+}

--- a/src/Atypical.VirtualFileSystem.Providers.Abstractions/AuthRequest.cs
+++ b/src/Atypical.VirtualFileSystem.Providers.Abstractions/AuthRequest.cs
@@ -1,0 +1,17 @@
+namespace Atypical.VirtualFileSystem.Providers.Abstractions;
+
+/// <summary>Kind-specific authentication payload. Only the fields relevant to the provider's AuthKind are used.</summary>
+public sealed record AuthRequest
+{
+    // Token providers (e.g. GitHub)
+    public string? Token { get; init; }
+
+    // Credentials providers (e.g. FTP)
+    public string? Host { get; init; }
+    public int Port { get; init; }
+    public string? Username { get; init; }
+    public string? Password { get; init; }
+    public bool UseTls { get; init; }
+}
+
+public sealed record AuthResult(bool Success, string? ErrorMessage, ProviderAccountInfo? Account);

--- a/src/Atypical.VirtualFileSystem.Providers.Abstractions/CommitContext.cs
+++ b/src/Atypical.VirtualFileSystem.Providers.Abstractions/CommitContext.cs
@@ -1,0 +1,13 @@
+namespace Atypical.VirtualFileSystem.Providers.Abstractions;
+
+/// <summary>
+/// Optional context for a write. Providers honor only what their capabilities allow
+/// and ignore the rest (e.g. FTP ignores all of these).
+/// </summary>
+public sealed record CommitContext
+{
+    public static readonly CommitContext Empty = new();
+    public string? Message { get; init; }
+    public string? Branch { get; init; }
+    public bool Draft { get; init; }
+}

--- a/src/Atypical.VirtualFileSystem.Providers.Abstractions/GlobalUsings.cs
+++ b/src/Atypical.VirtualFileSystem.Providers.Abstractions/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using Atypical.VirtualFileSystem.Core;
+global using Atypical.VirtualFileSystem.Core.Contracts;

--- a/src/Atypical.VirtualFileSystem.Providers.Abstractions/IStorageProvider.cs
+++ b/src/Atypical.VirtualFileSystem.Providers.Abstractions/IStorageProvider.cs
@@ -1,0 +1,15 @@
+namespace Atypical.VirtualFileSystem.Providers.Abstractions;
+
+/// <summary>A pluggable storage backend that can import into, and write back from, a VFS.</summary>
+public interface IStorageProvider
+{
+    string Id { get; }
+    string DisplayName { get; }
+    ProviderCapabilities Capabilities { get; }
+    IStorageProviderAuth Auth { get; }
+
+    Task<ProviderLoadResult> ImportAsync(IVirtualFileSystem vfs, ProviderLoadOptions options, CancellationToken cancellationToken = default);
+    Task<ProviderFileContent> ReadFileAsync(string remotePath, CancellationToken cancellationToken = default);
+    Task<ProviderWriteResult> WriteChangesAsync(IReadOnlyList<ProviderFileChange> changes, CommitContext context, CancellationToken cancellationToken = default);
+    Task<ProviderAccountInfo> GetAccountInfoAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Atypical.VirtualFileSystem.Providers.Abstractions/IStorageProvider.cs
+++ b/src/Atypical.VirtualFileSystem.Providers.Abstractions/IStorageProvider.cs
@@ -3,13 +3,50 @@ namespace Atypical.VirtualFileSystem.Providers.Abstractions;
 /// <summary>A pluggable storage backend that can import into, and write back from, a VFS.</summary>
 public interface IStorageProvider
 {
+    /// <summary>A stable, lowercase identifier for the provider (e.g. "github", "ftp").</summary>
     string Id { get; }
+
+    /// <summary>A human-readable name for the provider, suitable for display in a UI.</summary>
     string DisplayName { get; }
+
+    /// <summary>Describes which optional operations this provider supports.</summary>
     ProviderCapabilities Capabilities { get; }
+
+    /// <summary>The authentication handler for this provider.</summary>
     IStorageProviderAuth Auth { get; }
 
+    /// <summary>
+    /// Imports remote files into the given Virtual File System according to the supplied options.
+    /// </summary>
+    /// <param name="vfs">The Virtual File System to import the remote files into.</param>
+    /// <param name="options">Options controlling the import (root, strategy, filters, callbacks).</param>
+    /// <param name="cancellationToken">Cancellation token for the operation.</param>
+    /// <returns>A result summarizing the files loaded, directories created, and any skipped files.</returns>
     Task<ProviderLoadResult> ImportAsync(IVirtualFileSystem vfs, ProviderLoadOptions options, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads the content of a single remote file.
+    /// </summary>
+    /// <param name="remotePath">The provider-specific path of the file to read.</param>
+    /// <param name="cancellationToken">Cancellation token for the operation.</param>
+    /// <returns>The file content along with an opaque version token.</returns>
     Task<ProviderFileContent> ReadFileAsync(string remotePath, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Writes a batch of file changes (adds, updates, deletes) back to the remote storage.
+    /// </summary>
+    /// <param name="changes">The changes to apply.</param>
+    /// <param name="context">Optional commit context; providers honor only what their capabilities allow.</param>
+    /// <param name="cancellationToken">Cancellation token for the operation.</param>
+    /// <returns>A result reporting overall success and per-file outcomes.</returns>
     Task<ProviderWriteResult> WriteChangesAsync(IReadOnlyList<ProviderFileChange> changes, CommitContext context, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns identity and quota/limit information for the authenticated account.
+    /// When the provider is not authenticated this returns <see cref="ProviderAccountInfo.Anonymous"/>;
+    /// it never returns <see langword="null"/> and does not throw for the unauthenticated case.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token for the operation.</param>
+    /// <returns>The authenticated account's info, or <see cref="ProviderAccountInfo.Anonymous"/> when not authenticated.</returns>
     Task<ProviderAccountInfo> GetAccountInfoAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Atypical.VirtualFileSystem.Providers.Abstractions/IStorageProviderAuth.cs
+++ b/src/Atypical.VirtualFileSystem.Providers.Abstractions/IStorageProviderAuth.cs
@@ -1,11 +1,34 @@
 namespace Atypical.VirtualFileSystem.Providers.Abstractions;
 
+/// <summary>
+/// Handles authentication for a storage provider, exposing the current authenticated
+/// account and notifying subscribers when the authentication state changes.
+/// </summary>
 public interface IStorageProviderAuth
 {
+    /// <summary>The kind of authentication this provider uses (token, credentials, OAuth).</summary>
     AuthKind Kind { get; }
+
+    /// <summary>Whether the provider currently has a valid authenticated session.</summary>
     bool IsAuthenticated { get; }
+
+    /// <summary>The authenticated account, or <see langword="null"/> when not authenticated.</summary>
     ProviderAccountInfo? Account { get; }
+
+    /// <summary>
+    /// Attempts to authenticate using the supplied request payload.
+    /// </summary>
+    /// <param name="request">The kind-specific authentication payload.</param>
+    /// <param name="cancellationToken">Cancellation token for the operation.</param>
+    /// <returns>A result indicating success or failure, with the account on success.</returns>
     Task<AuthResult> AuthenticateAsync(AuthRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Clears the current authenticated session.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token for the operation.</param>
     Task SignOutAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Raised whenever the authentication state changes (sign-in or sign-out).</summary>
     event Action? AuthChanged;
 }

--- a/src/Atypical.VirtualFileSystem.Providers.Abstractions/IStorageProviderAuth.cs
+++ b/src/Atypical.VirtualFileSystem.Providers.Abstractions/IStorageProviderAuth.cs
@@ -1,0 +1,11 @@
+namespace Atypical.VirtualFileSystem.Providers.Abstractions;
+
+public interface IStorageProviderAuth
+{
+    AuthKind Kind { get; }
+    bool IsAuthenticated { get; }
+    ProviderAccountInfo? Account { get; }
+    Task<AuthResult> AuthenticateAsync(AuthRequest request, CancellationToken cancellationToken = default);
+    Task SignOutAsync(CancellationToken cancellationToken = default);
+    event Action? AuthChanged;
+}

--- a/src/Atypical.VirtualFileSystem.Providers.Abstractions/ProviderAccountInfo.cs
+++ b/src/Atypical.VirtualFileSystem.Providers.Abstractions/ProviderAccountInfo.cs
@@ -1,0 +1,14 @@
+namespace Atypical.VirtualFileSystem.Providers.Abstractions;
+
+/// <summary>Identity and quota/limit info for the authenticated account.</summary>
+public sealed record ProviderAccountInfo
+{
+    public static readonly ProviderAccountInfo Anonymous = new() { DisplayName = "Anonymous" };
+
+    public required string DisplayName { get; init; }
+    public long? QuotaUsedBytes { get; init; }
+    public long? QuotaTotalBytes { get; init; }
+    public int? RateLimitRemaining { get; init; }
+    public int? RateLimitTotal { get; init; }
+    public DateTimeOffset? RateLimitReset { get; init; }
+}

--- a/src/Atypical.VirtualFileSystem.Providers.Abstractions/ProviderCapabilities.cs
+++ b/src/Atypical.VirtualFileSystem.Providers.Abstractions/ProviderCapabilities.cs
@@ -1,0 +1,12 @@
+namespace Atypical.VirtualFileSystem.Providers.Abstractions;
+
+/// <summary>Describes which optional operations a storage provider supports.</summary>
+public sealed record ProviderCapabilities
+{
+    public bool SupportsBranches { get; init; }
+    public bool SupportsPullRequests { get; init; }
+    public bool SupportsFork { get; init; }
+    public bool SupportsAtomicMultiFileCommit { get; init; }
+    public bool SupportsVersioning { get; init; }
+    public AuthKind AuthKind { get; init; }
+}

--- a/src/Atypical.VirtualFileSystem.Providers.Abstractions/ProviderFileChange.cs
+++ b/src/Atypical.VirtualFileSystem.Providers.Abstractions/ProviderFileChange.cs
@@ -1,0 +1,11 @@
+namespace Atypical.VirtualFileSystem.Providers.Abstractions;
+
+public enum ChangeKind { Add, Update, Delete }
+
+public sealed record ProviderFileChange
+{
+    public required string RemotePath { get; init; }
+    public required ChangeKind Kind { get; init; }
+    public byte[]? Content { get; init; }
+    public string? BaseVersionToken { get; init; }
+}

--- a/src/Atypical.VirtualFileSystem.Providers.Abstractions/ProviderFileContent.cs
+++ b/src/Atypical.VirtualFileSystem.Providers.Abstractions/ProviderFileContent.cs
@@ -1,0 +1,4 @@
+namespace Atypical.VirtualFileSystem.Providers.Abstractions;
+
+/// <summary>The content of a single remote file plus an opaque version token (ETag/SHA/mtime).</summary>
+public sealed record ProviderFileContent(byte[] Content, string VersionToken, bool IsBinary);

--- a/src/Atypical.VirtualFileSystem.Providers.Abstractions/ProviderFileMetadata.cs
+++ b/src/Atypical.VirtualFileSystem.Providers.Abstractions/ProviderFileMetadata.cs
@@ -1,0 +1,11 @@
+namespace Atypical.VirtualFileSystem.Providers.Abstractions;
+
+/// <summary>Maps a VFS file back to its remote origin so writes can target the right place.</summary>
+public sealed record ProviderFileMetadata
+{
+    public required string ProviderId { get; init; }
+    public required string ContainerKey { get; init; }   // repo "owner/name" or host+base path
+    public required string RelativePath { get; init; }
+    public required string VersionToken { get; init; }
+    public DateTimeOffset ImportedAt { get; init; }
+}

--- a/src/Atypical.VirtualFileSystem.Providers.Abstractions/ProviderLoadOptions.cs
+++ b/src/Atypical.VirtualFileSystem.Providers.Abstractions/ProviderLoadOptions.cs
@@ -1,0 +1,19 @@
+namespace Atypical.VirtualFileSystem.Providers.Abstractions;
+
+public enum ProviderLoadingStrategy { Eager, Lazy, MetadataOnly }
+
+/// <summary>Options controlling an import into the VFS.</summary>
+public sealed record ProviderLoadOptions
+{
+    /// <summary>Remote sub-path to import from (provider-specific root if null/empty).</summary>
+    public string? RemoteRoot { get; init; }
+    public ProviderLoadingStrategy Strategy { get; init; } = ProviderLoadingStrategy.Eager;
+    public long MaxFileSizeBytes { get; init; } = 10 * 1024 * 1024;
+    public IReadOnlyList<string>? AllowedExtensions { get; init; }
+    public IReadOnlyList<string>? BlockedExtensions { get; init; }
+    public string? GlobPattern { get; init; }
+    /// <summary>Invoked as each file is loaded: (vfsPath, remotePath, versionToken).</summary>
+    public Action<string, string, string>? MetadataCallback { get; init; }
+    /// <summary>Invoked for progress: (filesLoaded, message).</summary>
+    public Action<int, string>? ProgressCallback { get; init; }
+}

--- a/src/Atypical.VirtualFileSystem.Providers.Abstractions/ProviderLoadResult.cs
+++ b/src/Atypical.VirtualFileSystem.Providers.Abstractions/ProviderLoadResult.cs
@@ -1,0 +1,15 @@
+namespace Atypical.VirtualFileSystem.Providers.Abstractions;
+
+public enum ProviderSkipReason { TooLarge, BlockedExtension, NotMatchingGlob, LoadError }
+
+public sealed record ProviderSkippedFile(string RemotePath, ProviderSkipReason Reason, long SizeBytes, string? Message);
+
+public sealed record ProviderLoadResult
+{
+    public required string RemoteRoot { get; init; }
+    public int FilesLoaded { get; init; }
+    public int DirectoriesCreated { get; init; }
+    public long TotalBytes { get; init; }
+    public IReadOnlyList<ProviderSkippedFile> Skipped { get; init; } = [];
+    public TimeSpan Duration { get; init; }
+}

--- a/src/Atypical.VirtualFileSystem.Providers.Abstractions/ProviderWriteResult.cs
+++ b/src/Atypical.VirtualFileSystem.Providers.Abstractions/ProviderWriteResult.cs
@@ -1,0 +1,12 @@
+namespace Atypical.VirtualFileSystem.Providers.Abstractions;
+
+public sealed record ProviderFileWriteResult(string RemotePath, bool Success, string? Message);
+
+public sealed record ProviderWriteResult
+{
+    public required bool Success { get; init; }
+    public IReadOnlyList<ProviderFileWriteResult> FileResults { get; init; } = [];
+    /// <summary>For PR-capable providers, the URL of the created pull request (else null).</summary>
+    public string? PullRequestUrl { get; init; }
+    public string? Message { get; init; }
+}

--- a/tests/Atypical.VirtualFileSystem.Ftp.Tests/Atypical.VirtualFileSystem.Ftp.Tests.csproj
+++ b/tests/Atypical.VirtualFileSystem.Ftp.Tests/Atypical.VirtualFileSystem.Ftp.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <RootNamespace>Atypical.VirtualFileSystem.Ftp.Tests</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Shouldly" Version="4.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="8.0.1">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Atypical.VirtualFileSystem.Ftp\Atypical.VirtualFileSystem.Ftp.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Atypical.VirtualFileSystem.Ftp.Tests/FakeFtpConnection.cs
+++ b/tests/Atypical.VirtualFileSystem.Ftp.Tests/FakeFtpConnection.cs
@@ -16,9 +16,9 @@ public sealed class FakeFtpConnection : IFtpConnection
         var dir = remoteDir.TrimEnd('/');
         IReadOnlyList<FtpRemoteItem> Children() =>
             Directories.Where(d => ParentOf(d) == dir)
-                .Select(d => new FtpRemoteItem(d, true, 0, DateTime.UnixEpoch))
+                .Select(d => new FtpRemoteItem(d, true, 0, DateTimeOffset.UnixEpoch))
                 .Concat(Files.Where(f => ParentOf(f.Key) == dir)
-                    .Select(f => new FtpRemoteItem(f.Key, false, f.Value.Length, DateTime.UnixEpoch)))
+                    .Select(f => new FtpRemoteItem(f.Key, false, f.Value.Length, DateTimeOffset.UnixEpoch)))
                 .ToList();
         return Task.FromResult(Children());
     }

--- a/tests/Atypical.VirtualFileSystem.Ftp.Tests/FakeFtpConnection.cs
+++ b/tests/Atypical.VirtualFileSystem.Ftp.Tests/FakeFtpConnection.cs
@@ -1,0 +1,48 @@
+namespace Atypical.VirtualFileSystem.Ftp.Tests;
+
+/// <summary>In-memory FTP server: a path->bytes map plus directory entries.</summary>
+public sealed class FakeFtpConnection : IFtpConnection
+{
+    public Dictionary<string, byte[]> Files { get; } = new();
+    public HashSet<string> Directories { get; } = new();
+    public List<string> Uploaded { get; } = new();
+    public List<string> Deleted { get; } = new();
+
+    public Task ConnectAsync(CancellationToken ct) => Task.CompletedTask;
+    public Task DisconnectAsync(CancellationToken ct) => Task.CompletedTask;
+
+    public Task<IReadOnlyList<FtpRemoteItem>> ListAsync(string remoteDir, CancellationToken ct)
+    {
+        var dir = remoteDir.TrimEnd('/');
+        IReadOnlyList<FtpRemoteItem> Children() =>
+            Directories.Where(d => ParentOf(d) == dir)
+                .Select(d => new FtpRemoteItem(d, true, 0, DateTime.UnixEpoch))
+                .Concat(Files.Where(f => ParentOf(f.Key) == dir)
+                    .Select(f => new FtpRemoteItem(f.Key, false, f.Value.Length, DateTime.UnixEpoch)))
+                .ToList();
+        return Task.FromResult(Children());
+    }
+
+    public Task<byte[]> DownloadAsync(string remotePath, CancellationToken ct) => Task.FromResult(Files[remotePath]);
+
+    public Task UploadAsync(string remotePath, byte[] content, CancellationToken ct)
+    {
+        Files[remotePath] = content;
+        Uploaded.Add(remotePath);
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteFileAsync(string remotePath, CancellationToken ct)
+    {
+        Files.Remove(remotePath);
+        Deleted.Add(remotePath);
+        return Task.CompletedTask;
+    }
+
+    private static string ParentOf(string path)
+    {
+        var p = path.TrimEnd('/');
+        var idx = p.LastIndexOf('/');
+        return idx <= 0 ? "" : p[..idx];
+    }
+}

--- a/tests/Atypical.VirtualFileSystem.Ftp.Tests/FtpStorageProviderImportTests.cs
+++ b/tests/Atypical.VirtualFileSystem.Ftp.Tests/FtpStorageProviderImportTests.cs
@@ -1,0 +1,42 @@
+namespace Atypical.VirtualFileSystem.Ftp.Tests;
+
+public class FtpStorageProviderImportTests
+{
+    private static FakeFtpConnection BuildTree()
+    {
+        var fake = new FakeFtpConnection();
+        fake.Directories.Add("/data");
+        fake.Directories.Add("/data/sub");
+        fake.Files["/data/readme.txt"] = "hello"u8.ToArray();
+        fake.Files["/data/sub/a.txt"] = "A"u8.ToArray();
+        fake.Files["/data/big.bin"] = new byte[20]; // for size-filter test
+        return fake;
+    }
+
+    [Fact]
+    public async Task ImportAsync_loads_files_recursively_into_the_vfs()
+    {
+        var fake = BuildTree();
+        var provider = new FtpStorageProvider(_ => fake);
+        var vfs = new VFS();
+
+        var result = await provider.ImportAsync(vfs, new ProviderLoadOptions { RemoteRoot = "/data" });
+
+        result.FilesLoaded.ShouldBe(3);
+        vfs.Index.ContainsKey(new VFSFilePath("data/readme.txt")).ShouldBeTrue();
+        vfs.Index.ContainsKey(new VFSFilePath("data/sub/a.txt")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ImportAsync_skips_files_over_the_max_size()
+    {
+        var fake = BuildTree();
+        var provider = new FtpStorageProvider(_ => fake);
+        var vfs = new VFS();
+
+        var result = await provider.ImportAsync(vfs, new ProviderLoadOptions { RemoteRoot = "/data", MaxFileSizeBytes = 10 });
+
+        result.Skipped.ShouldContain(s => s.RemotePath == "/data/big.bin" && s.Reason == ProviderSkipReason.TooLarge);
+        vfs.Index.ContainsKey(new VFSFilePath("data/big.bin")).ShouldBeFalse();
+    }
+}

--- a/tests/Atypical.VirtualFileSystem.Ftp.Tests/FtpStorageProviderImportTests.cs
+++ b/tests/Atypical.VirtualFileSystem.Ftp.Tests/FtpStorageProviderImportTests.cs
@@ -13,14 +13,22 @@ public class FtpStorageProviderImportTests
         return fake;
     }
 
+    private static async Task<FtpStorageProvider> AuthedProviderAsync(FakeFtpConnection fake)
+    {
+        var provider = new FtpStorageProvider(_ => fake);
+        await provider.Auth.AuthenticateAsync(new AuthRequest { Host = "h", Username = "u", Password = "p" });
+        return provider;
+    }
+
     [Fact]
     public async Task ImportAsync_loads_files_recursively_into_the_vfs()
     {
         var fake = BuildTree();
-        var provider = new FtpStorageProvider(_ => fake);
+        var provider = await AuthedProviderAsync(fake);
         var vfs = new VFS();
 
-        var result = await provider.ImportAsync(vfs, new ProviderLoadOptions { RemoteRoot = "/data" });
+        // No size cap so all three files (including the 20-byte big.bin) load.
+        var result = await provider.ImportAsync(vfs, new ProviderLoadOptions { RemoteRoot = "/data", MaxFileSizeBytes = long.MaxValue });
 
         result.FilesLoaded.ShouldBe(3);
         vfs.Index.ContainsKey(new VFSFilePath("data/readme.txt")).ShouldBeTrue();
@@ -31,12 +39,27 @@ public class FtpStorageProviderImportTests
     public async Task ImportAsync_skips_files_over_the_max_size()
     {
         var fake = BuildTree();
-        var provider = new FtpStorageProvider(_ => fake);
+        var provider = await AuthedProviderAsync(fake);
         var vfs = new VFS();
 
         var result = await provider.ImportAsync(vfs, new ProviderLoadOptions { RemoteRoot = "/data", MaxFileSizeBytes = 10 });
 
         result.Skipped.ShouldContain(s => s.RemotePath == "/data/big.bin" && s.Reason == ProviderSkipReason.TooLarge);
         vfs.Index.ContainsKey(new VFSFilePath("data/big.bin")).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ImportAsync_materializes_empty_directories_in_the_vfs()
+    {
+        var fake = new FakeFtpConnection();
+        fake.Directories.Add("/data");
+        fake.Directories.Add("/data/empty"); // empty subdirectory: no files inside
+        var provider = await AuthedProviderAsync(fake);
+        var vfs = new VFS();
+
+        var result = await provider.ImportAsync(vfs, new ProviderLoadOptions { RemoteRoot = "/data" });
+
+        result.FilesLoaded.ShouldBe(0);
+        vfs.Index.ContainsKey(new VFSDirectoryPath("data/empty")).ShouldBeTrue();
     }
 }

--- a/tests/Atypical.VirtualFileSystem.Ftp.Tests/FtpStorageProviderWriteTests.cs
+++ b/tests/Atypical.VirtualFileSystem.Ftp.Tests/FtpStorageProviderWriteTests.cs
@@ -1,0 +1,47 @@
+namespace Atypical.VirtualFileSystem.Ftp.Tests;
+
+public class FtpStorageProviderWriteTests
+{
+    private static FtpStorageProvider AuthedProvider(FakeFtpConnection fake)
+    {
+        var provider = new FtpStorageProvider(_ => fake);
+        // authenticate (fake connect succeeds)
+        provider.Auth.AuthenticateAsync(new AuthRequest { Host = "h", Username = "u", Password = "p" }).GetAwaiter().GetResult();
+        return provider;
+    }
+
+    [Fact]
+    public async Task WriteChangesAsync_uploads_adds_and_updates_and_reports_per_file()
+    {
+        var fake = new FakeFtpConnection();
+        var provider = AuthedProvider(fake);
+
+        var changes = new List<ProviderFileChange>
+        {
+            new() { RemotePath = "/data/new.txt", Kind = ChangeKind.Add, Content = "x"u8.ToArray() },
+            new() { RemotePath = "/data/edit.txt", Kind = ChangeKind.Update, Content = "y"u8.ToArray() },
+        };
+
+        var result = await provider.WriteChangesAsync(changes, CommitContext.Empty);
+
+        result.Success.ShouldBeTrue();
+        result.FileResults.Count.ShouldBe(2);
+        fake.Uploaded.ShouldContain("/data/new.txt");
+        fake.Files["/data/edit.txt"].ShouldBe("y"u8.ToArray());
+        result.PullRequestUrl.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task WriteChangesAsync_deletes_files()
+    {
+        var fake = new FakeFtpConnection();
+        fake.Files["/data/gone.txt"] = "z"u8.ToArray();
+        var provider = AuthedProvider(fake);
+
+        var result = await provider.WriteChangesAsync(
+            [new() { RemotePath = "/data/gone.txt", Kind = ChangeKind.Delete }], CommitContext.Empty);
+
+        result.Success.ShouldBeTrue();
+        fake.Deleted.ShouldContain("/data/gone.txt");
+    }
+}

--- a/tests/Atypical.VirtualFileSystem.Ftp.Tests/FtpStorageProviderWriteTests.cs
+++ b/tests/Atypical.VirtualFileSystem.Ftp.Tests/FtpStorageProviderWriteTests.cs
@@ -2,11 +2,11 @@ namespace Atypical.VirtualFileSystem.Ftp.Tests;
 
 public class FtpStorageProviderWriteTests
 {
-    private static FtpStorageProvider AuthedProvider(FakeFtpConnection fake)
+    private static async Task<FtpStorageProvider> AuthedProviderAsync(FakeFtpConnection fake)
     {
         var provider = new FtpStorageProvider(_ => fake);
         // authenticate (fake connect succeeds)
-        provider.Auth.AuthenticateAsync(new AuthRequest { Host = "h", Username = "u", Password = "p" }).GetAwaiter().GetResult();
+        await provider.Auth.AuthenticateAsync(new AuthRequest { Host = "h", Username = "u", Password = "p" });
         return provider;
     }
 
@@ -14,7 +14,7 @@ public class FtpStorageProviderWriteTests
     public async Task WriteChangesAsync_uploads_adds_and_updates_and_reports_per_file()
     {
         var fake = new FakeFtpConnection();
-        var provider = AuthedProvider(fake);
+        var provider = await AuthedProviderAsync(fake);
 
         var changes = new List<ProviderFileChange>
         {
@@ -36,7 +36,7 @@ public class FtpStorageProviderWriteTests
     {
         var fake = new FakeFtpConnection();
         fake.Files["/data/gone.txt"] = "z"u8.ToArray();
-        var provider = AuthedProvider(fake);
+        var provider = await AuthedProviderAsync(fake);
 
         var result = await provider.WriteChangesAsync(
             [new() { RemotePath = "/data/gone.txt", Kind = ChangeKind.Delete }], CommitContext.Empty);

--- a/tests/Atypical.VirtualFileSystem.Ftp.Tests/GlobalUsings.cs
+++ b/tests/Atypical.VirtualFileSystem.Ftp.Tests/GlobalUsings.cs
@@ -1,0 +1,5 @@
+global using Atypical.VirtualFileSystem.Core;
+global using Atypical.VirtualFileSystem.Ftp;
+global using Atypical.VirtualFileSystem.Providers.Abstractions;
+global using Shouldly;
+global using Xunit;

--- a/tests/Atypical.VirtualFileSystem.GitHub.Tests/Providers/GitHubProviderAdaptersTests.cs
+++ b/tests/Atypical.VirtualFileSystem.GitHub.Tests/Providers/GitHubProviderAdaptersTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) 2022-2025, Atypical Consulting SRL
+// All rights reserved... but seriously, we're open to sharing if you ask nicely!
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+using Atypical.VirtualFileSystem.GitHub.Providers;
+using Atypical.VirtualFileSystem.Providers.Abstractions;
+
+namespace Atypical.VirtualFileSystem.GitHub.Tests.Providers;
+
+public class GitHubProviderAdaptersTests
+{
+    [Fact]
+    public void ToGitHubLoaderOptions_maps_strategy_and_filters()
+    {
+        var opts = new ProviderLoadOptions
+        {
+            RemoteRoot = "src",
+            Strategy = ProviderLoadingStrategy.Lazy,
+            MaxFileSizeBytes = 1234,
+        };
+
+        var gh = GitHubProviderAdapters.ToGitHubLoaderOptions(opts, accessToken: "tok");
+
+        gh.Strategy.ShouldBe(GitHubLoadingStrategy.Lazy);
+        gh.MaxFileSize.ShouldBe(1234);
+        gh.TargetPath.ShouldBe("src");
+        gh.AccessToken.ShouldBe("tok");
+    }
+
+    [Fact]
+    public void ToProviderLoadResult_maps_counts_and_skips()
+    {
+        var ghResult = new GitHubLoadResult(
+            RepositoryOwner: "o",
+            RepositoryName: "r",
+            Branch: "main",
+            CommitSha: "sha",
+            FilesLoaded: 3,
+            DirectoriesCreated: 2,
+            TotalBytesLoaded: 99,
+            SkippedFiles: new List<GitHubSkippedFile> { new("a.bin", SkipReason.LoadError, 5, "boom") },
+            LoadDuration: TimeSpan.FromSeconds(1),
+            TargetPath: "src");
+
+        var result = GitHubProviderAdapters.ToProviderLoadResult(ghResult);
+
+        result.FilesLoaded.ShouldBe(3);
+        result.DirectoriesCreated.ShouldBe(2);
+        result.TotalBytes.ShouldBe(99);
+        result.Skipped.Count.ShouldBe(1);
+        result.Skipped[0].Reason.ShouldBe(ProviderSkipReason.LoadError);
+    }
+}

--- a/tests/Atypical.VirtualFileSystem.GitHub.Tests/Providers/GitHubProviderAdaptersTests.cs
+++ b/tests/Atypical.VirtualFileSystem.GitHub.Tests/Providers/GitHubProviderAdaptersTests.cs
@@ -46,11 +46,13 @@ public class GitHubProviderAdaptersTests
             LoadDuration: TimeSpan.FromSeconds(1),
             TargetPath: "src");
 
-        var result = GitHubProviderAdapters.ToProviderLoadResult(ghResult);
+        var result = GitHubProviderAdapters.ToProviderLoadResult(ghResult, requestedRemoteRoot: "o/r/src");
 
+        result.RemoteRoot.ShouldBe("o/r/src");
         result.FilesLoaded.ShouldBe(3);
         result.DirectoriesCreated.ShouldBe(2);
         result.TotalBytes.ShouldBe(99);
+        result.Duration.ShouldBe(TimeSpan.FromSeconds(1));
         result.Skipped.Count.ShouldBe(1);
         result.Skipped[0].Reason.ShouldBe(ProviderSkipReason.LoadError);
     }

--- a/tests/Atypical.VirtualFileSystem.GitHub.Tests/Providers/GitHubProviderAdaptersTests.cs
+++ b/tests/Atypical.VirtualFileSystem.GitHub.Tests/Providers/GitHubProviderAdaptersTests.cs
@@ -25,7 +25,9 @@ public class GitHubProviderAdaptersTests
 
         gh.Strategy.ShouldBe(GitHubLoadingStrategy.Lazy);
         gh.MaxFileSize.ShouldBe(1234);
-        gh.TargetPath.ShouldBe("src");
+        // RemoteRoot maps to the REMOTE filter (SubPath), not the VFS destination (TargetPath).
+        gh.SubPath.ShouldBe("src");
+        gh.TargetPath.ShouldBe("/");
         gh.AccessToken.ShouldBe("tok");
     }
 

--- a/tests/Atypical.VirtualFileSystem.GitHub.Tests/Providers/GitHubProviderAuthTests.cs
+++ b/tests/Atypical.VirtualFileSystem.GitHub.Tests/Providers/GitHubProviderAuthTests.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2022-2025, Atypical Consulting SRL
+// All rights reserved... but seriously, we're open to sharing if you ask nicely!
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+using Atypical.VirtualFileSystem.GitHub.Providers;
+using Atypical.VirtualFileSystem.Providers.Abstractions;
+
+namespace Atypical.VirtualFileSystem.GitHub.Tests.Providers;
+
+public class GitHubProviderAuthTests
+{
+    [Fact]
+    public void New_auth_is_token_kind_and_unauthenticated()
+    {
+        var auth = new GitHubProviderAuth();
+        auth.Kind.ShouldBe(AuthKind.Token);
+        auth.IsAuthenticated.ShouldBeFalse();
+        auth.Account.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_with_empty_token_returns_failure()
+    {
+        var auth = new GitHubProviderAuth();
+        var result = await auth.AuthenticateAsync(new AuthRequest { Token = "" });
+        result.Success.ShouldBeFalse();
+    }
+}

--- a/tests/Atypical.VirtualFileSystem.GitHub.Tests/Providers/GitHubStorageProviderTests.cs
+++ b/tests/Atypical.VirtualFileSystem.GitHub.Tests/Providers/GitHubStorageProviderTests.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2022-2025, Atypical Consulting SRL
+// All rights reserved... but seriously, we're open to sharing if you ask nicely!
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+using Atypical.VirtualFileSystem.GitHub.Providers;
+using Atypical.VirtualFileSystem.Providers.Abstractions;
+
+namespace Atypical.VirtualFileSystem.GitHub.Tests.Providers;
+
+public class GitHubStorageProviderTests
+{
+    [Fact]
+    public void Provider_exposes_github_id_and_pr_capabilities()
+    {
+        var provider = new GitHubStorageProvider(new GitHubRepositoryLoader(), new GitHubWriteService(), new GitHubProviderAuth());
+        provider.Id.ShouldBe("github");
+        provider.Capabilities.SupportsPullRequests.ShouldBeTrue();
+        provider.Capabilities.SupportsBranches.ShouldBeTrue();
+        provider.Capabilities.SupportsAtomicMultiFileCommit.ShouldBeTrue();
+        provider.Capabilities.AuthKind.ShouldBe(AuthKind.Token);
+    }
+}

--- a/tests/Atypical.VirtualFileSystem.Providers.Abstractions.Tests/Atypical.VirtualFileSystem.Providers.Abstractions.Tests.csproj
+++ b/tests/Atypical.VirtualFileSystem.Providers.Abstractions.Tests/Atypical.VirtualFileSystem.Providers.Abstractions.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <RootNamespace>Atypical.VirtualFileSystem.Providers.Abstractions.Tests</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Shouldly" Version="4.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="8.0.1">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Atypical.VirtualFileSystem.Providers.Abstractions\Atypical.VirtualFileSystem.Providers.Abstractions.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Atypical.VirtualFileSystem.Providers.Abstractions.Tests/CommitContextTests.cs
+++ b/tests/Atypical.VirtualFileSystem.Providers.Abstractions.Tests/CommitContextTests.cs
@@ -1,0 +1,22 @@
+namespace Atypical.VirtualFileSystem.Providers.Abstractions.Tests;
+
+public class CommitContextTests
+{
+    [Fact]
+    public void Empty_has_no_message_branch_or_draft()
+    {
+        var ctx = CommitContext.Empty;
+        ctx.Message.ShouldBeNull();
+        ctx.Branch.ShouldBeNull();
+        ctx.Draft.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Capabilities_default_to_false_with_token_auth()
+    {
+        var caps = new ProviderCapabilities();
+        caps.SupportsBranches.ShouldBeFalse();
+        caps.SupportsPullRequests.ShouldBeFalse();
+        caps.AuthKind.ShouldBe(AuthKind.Token);
+    }
+}

--- a/tests/Atypical.VirtualFileSystem.Providers.Abstractions.Tests/CommitContextTests.cs
+++ b/tests/Atypical.VirtualFileSystem.Providers.Abstractions.Tests/CommitContextTests.cs
@@ -10,13 +10,4 @@ public class CommitContextTests
         ctx.Branch.ShouldBeNull();
         ctx.Draft.ShouldBeFalse();
     }
-
-    [Fact]
-    public void Capabilities_default_to_false_with_token_auth()
-    {
-        var caps = new ProviderCapabilities();
-        caps.SupportsBranches.ShouldBeFalse();
-        caps.SupportsPullRequests.ShouldBeFalse();
-        caps.AuthKind.ShouldBe(AuthKind.Token);
-    }
 }

--- a/tests/Atypical.VirtualFileSystem.Providers.Abstractions.Tests/GlobalUsings.cs
+++ b/tests/Atypical.VirtualFileSystem.Providers.Abstractions.Tests/GlobalUsings.cs
@@ -1,0 +1,3 @@
+global using Atypical.VirtualFileSystem.Providers.Abstractions;
+global using Shouldly;
+global using Xunit;

--- a/tests/Atypical.VirtualFileSystem.Providers.Abstractions.Tests/ProviderAccountInfoTests.cs
+++ b/tests/Atypical.VirtualFileSystem.Providers.Abstractions.Tests/ProviderAccountInfoTests.cs
@@ -1,0 +1,17 @@
+namespace Atypical.VirtualFileSystem.Providers.Abstractions.Tests;
+
+public class ProviderAccountInfoTests
+{
+    [Fact]
+    public void Anonymous_has_anonymous_display_name_and_null_quota_and_rate_fields()
+    {
+        var account = ProviderAccountInfo.Anonymous;
+
+        account.DisplayName.ShouldBe("Anonymous");
+        account.QuotaUsedBytes.ShouldBeNull();
+        account.QuotaTotalBytes.ShouldBeNull();
+        account.RateLimitRemaining.ShouldBeNull();
+        account.RateLimitTotal.ShouldBeNull();
+        account.RateLimitReset.ShouldBeNull();
+    }
+}

--- a/tests/Atypical.VirtualFileSystem.Providers.Abstractions.Tests/ProviderCapabilitiesTests.cs
+++ b/tests/Atypical.VirtualFileSystem.Providers.Abstractions.Tests/ProviderCapabilitiesTests.cs
@@ -1,0 +1,13 @@
+namespace Atypical.VirtualFileSystem.Providers.Abstractions.Tests;
+
+public class ProviderCapabilitiesTests
+{
+    [Fact]
+    public void Capabilities_default_to_false_with_token_auth()
+    {
+        var caps = new ProviderCapabilities();
+        caps.SupportsBranches.ShouldBeFalse();
+        caps.SupportsPullRequests.ShouldBeFalse();
+        caps.AuthKind.ShouldBe(AuthKind.Token);
+    }
+}

--- a/tests/Atypical.VirtualFileSystem.Providers.Abstractions.Tests/ProviderLoadOptionsTests.cs
+++ b/tests/Atypical.VirtualFileSystem.Providers.Abstractions.Tests/ProviderLoadOptionsTests.cs
@@ -1,0 +1,13 @@
+namespace Atypical.VirtualFileSystem.Providers.Abstractions.Tests;
+
+public class ProviderLoadOptionsTests
+{
+    [Fact]
+    public void Defaults_use_eager_strategy_and_ten_megabyte_max_file_size()
+    {
+        var options = new ProviderLoadOptions();
+
+        options.Strategy.ShouldBe(ProviderLoadingStrategy.Eager);
+        options.MaxFileSizeBytes.ShouldBe(10 * 1024 * 1024);
+    }
+}

--- a/tests/Atypical.VirtualFileSystem.Providers.Abstractions.Tests/ProviderWriteResultTests.cs
+++ b/tests/Atypical.VirtualFileSystem.Providers.Abstractions.Tests/ProviderWriteResultTests.cs
@@ -1,0 +1,26 @@
+namespace Atypical.VirtualFileSystem.Providers.Abstractions.Tests;
+
+public class ProviderWriteResultTests
+{
+    [Fact]
+    public void Result_with_one_failed_file_result_round_trips()
+    {
+        var result = new ProviderWriteResult
+        {
+            Success = false,
+            FileResults =
+            [
+                new ProviderFileWriteResult("/data/file.txt", false, "boom")
+            ],
+            Message = "write failed"
+        };
+
+        result.Success.ShouldBeFalse();
+        result.PullRequestUrl.ShouldBeNull();
+        result.Message.ShouldBe("write failed");
+        result.FileResults.Count.ShouldBe(1);
+        result.FileResults[0].RemotePath.ShouldBe("/data/file.txt");
+        result.FileResults[0].Success.ShouldBeFalse();
+        result.FileResults[0].Message.ShouldBe("boom");
+    }
+}


### PR DESCRIPTION
## Summary

Introduces a storage-provider abstraction so the VFS can load from / write to multiple backends, migrates the existing GitHub support onto it **with no behavior change**, and adds a read+write **FTP** provider with a capability-driven Blazor UI. Built per the design spec & plan under `docs/superpowers/` (merged via #167).

- **`Atypical.VirtualFileSystem.Providers.Abstractions` (new):** `IStorageProvider`, `IStorageProviderAuth`, `ProviderCapabilities`, and neutral records. Branch/PR/fork are capability flags + `CommitContext` fields (not base-interface methods), so providers that can't do PRs (FTP) simply ignore them.
- **GitHub migration:** `GitHubStorageProvider`/`GitHubProviderAuth`/adapters wrap the existing Octokit loader & write service — the original 71 GitHub tests still pass (regression gate).
- **`Atypical.VirtualFileSystem.Ftp` (new):** `FtpStorageProvider` over FluentFTP behind an `IFtpConnection` seam (TDD against an in-memory fake) — recursive import with size filtering, read, and write (per-file overwrite/delete with partial-success results), leak-safe connect/disconnect, TLS opt-in.
- **Blazor:** `IStorageProviderRegistry` selects the active provider; a capability-driven import dialog (provider picker) and capability-gated "submit changes" (PR for GitHub, upload for FTP). GitHub import/PR flows preserved unchanged; FTP credentials persisted encrypted via `ProtectedLocalStorage`.

Each phase was implemented test-first and passed spec + code-quality review.

## Follow-ups (out of scope, tracked)
- FTP write-back change-tracking (the upload path is plumbed + tested; the change-set tracker is deferred).
- Route GitHub through the neutral provider to retire the legacy GitHub-named services.
- Apply extension/glob filters in FTP import; rename `GitHubImportDialog` → `StorageImportDialog`.
- OneDrive (Microsoft Graph + OAuth) — see issue #132.

## Test plan
- [x] `dotnet build Atypical.VirtualFileSystem.sln -c Release` — 0 errors
- [x] `dotnet test` — 970 test runs pass on net9.0 + net10.0 (399 Core + 76 GitHub + 5 Abstractions + 5 FTP, ×2 TFMs)
- [x] DemoBlazorApp starts cleanly; GitHub flow unchanged, FTP provider selectable & imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)