### PR TITLE
fix(ci): skip release-draft update on pull_request events

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -25,6 +25,10 @@ jobs:
       # otherwise, read permission is required at least
       pull-requests: write
     runs-on: ubuntu-latest
+    # Only update the release draft on push to main, not on pull_request events.
+    # Running on PRs causes "Validation Failed: target_commitish" because
+    # release-drafter tries to set refs/pull/NNN/merge as the release target.
+    if: github.event_name == 'push'
     steps:
       # (Optional) GitHub Enterprise requires GHE_HOST variable set
       #- name: Set GHE_HOST


### PR DESCRIPTION
## Summary
Brings the Release Drafter `target_commitish` fix to **dev**. Gates the `update_release_draft` job with `if: github.event_name == 'push'` so it no longer fails on every PR with "Validation Failed: target_commitish", while keeping the `pull_request` trigger so the autolabeler can be enabled later.

This is the focused workflow-only change from #161 (that PR was based on a stale `main` and carried ~14k lines of unrelated commits, so it was not suitable to merge into dev directly).

## Test plan
- [x] Single-file change to `.github/workflows/release-drafter.yml`; takes effect on the next push/PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)