### PR TITLE
ci: make the NuGet publish actually work, via Trusted Publishing

### DIFF
--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -57,12 +57,16 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      id-token: write # request the GitHub OIDC token for NuGet Trusted Publishing
+
     steps:
       - uses: actions/checkout@v6
 
       - name: Get Build Version
         run: |
-          Import-Module .\build\GetBuildVersion.psm1
+          Import-Module ./build/GetBuildVersion.psm1
           Write-Host $Env:GITHUB_REF
           $version = GetBuildVersion -VersionString $Env:GITHUB_REF
           echo "BUILD_VERSION=$version" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
@@ -73,6 +77,28 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      # The version comes from the tag, overriding the hard-coded <Version> in
+      # Directory.Build.props — without -p:Version every tag would publish that literal instead.
+      - name: Pack
+        run: |
+          dotnet pack src/Atypical.VirtualFileSystem.Core/Atypical.VirtualFileSystem.Core.csproj \
+            --configuration Release -p:Version=$BUILD_VERSION --output ./artifacts
+          dotnet pack src/Atypical.VirtualFileSystem.GitHub/Atypical.VirtualFileSystem.GitHub.csproj \
+            --configuration Release -p:Version=$BUILD_VERSION --output ./artifacts
+
+      # Trusted Publishing: exchanges the OIDC token for a NuGet key valid ~1 hour, so no
+      # long-lived secret is stored. Requires a Trusted Publishing policy on nuget.org covering
+      # Atypical.VirtualFileSystem and Atypical.VirtualFileSystem.GitHub, naming this repository
+      # and publish-to-nuget.yml, plus the NUGET_USER secret (the nuget.org profile name).
+      - name: NuGet login (OIDC -> short-lived key)
+        id: nuget-login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Publish to NuGet
-        if: startsWith(github.ref, 'refs/tags')
-        run: nuget push **\*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}
+        run: |
+          dotnet nuget push "./artifacts/*.nupkg" \
+            --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate


### PR DESCRIPTION
This started as a credential migration and turned into a repair. **The publish job held a live `NUGET_API_KEY` while being incapable of publishing anything.**

`gh run list --workflow=publish-to-nuget.yml` returns nothing — this workflow has **never run once**, so none of the following ever surfaced:

| Fault | Consequence |
|---|---|
| It never packed | The job checked out, computed a version, installed the SDK, then pushed packages that did not exist. `build`/`test` run on separate runners and nothing carried their output over. |
| `nuget push` | The `nuget.exe` CLI, which is not present on `ubuntu-latest`. |
| `**\*.nupkg` | A Windows-shaped glob. |
| `BUILD_VERSION` unused | Computed from the tag, then discarded — any release would have shipped the literal `<Version>0.5.0</Version>` from `Directory.Build.props`. |
| `Import-Module .\build\…` | Backslash path, on a Linux runner. |

### What it does now

Packs both packable projects (`Atypical.VirtualFileSystem`, `Atypical.VirtualFileSystem.GitHub`) with `-p:Version=$BUILD_VERSION` so the tag actually governs the version, pushes with `dotnet nuget push`, and authorizes through **Trusted Publishing** — GitHub's OIDC token exchanged for a key valid ~1 hour, no long-lived secret stored. The only remaining secret is `NUGET_USER`, the nuget.org profile name.

### Please review this one more carefully than its siblings

The other six repos in this sweep were credential swaps on working pipelines. This one changes behaviour on a path that has never executed, which means **CI passing here proves less than usual** — the first real tag is the first genuine test. I would rather you knew that than discover it at release time.

### Required before the first release

1. Register a Trusted Publishing policy on nuget.org covering **both** ids, naming `Atypical-Consulting/VirtualFileSystem` and `publish-to-nuget.yml`.
2. Set the `NUGET_USER` secret.
3. Tag, confirm both packages appear at the tag's version, **then** delete `NUGET_API_KEY`.