### PR TITLE
chore: target net10.0 only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,8 @@
 name: CI
 on:
   push:
-    branches: [develop]
+    branches: [dev]
   pull_request:
-    branches: [develop]
   workflow_dispatch:
 jobs:
   build-and-test:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>13</LangVersion>


### PR DESCRIPTION
Retire la jambe **net9.0**, hors support depuis le 12/05/2026. Le package n'a jamais cible net8, il n'y a donc pas de consommateur LTS a proteger : on passe a net10 seul.

**Verdict de l'oracle local** : `GREEN` -> `GREEN`.