### PR TITLE
Build: publish symbols and Source Link with the packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,18 @@
     <Company>Atypical Consulting SRL</Company>
   </PropertyGroup>
 
+  <!-- Source Link -->
+  <!-- Consumed alongside DotNet.ReproducibleBuilds in the packable projects, which also turns on
+       deterministic builds and DebugType=embedded: the portable PDB then travels INSIDE the
+       assembly, so consumers can step into this code with no symbol-server configuration.
+       Deliberately NOT paired with IncludeSymbols/SymbolPackageFormat=snupkg — with embedded PDBs
+       no separate .pdb exists, so the snupkg would be packed empty and nuget.org rejects those
+       outright ("The package does not contain any symbol (.pdb) files"). -->
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
   <!-- Versioning -->
   <!-- https://saebamini.com/how-to-version-your-net-nuget-packages-libraries-and-assemblies-azure-yaml-pipelines-example-using-net-core-cli/ -->
   <PropertyGroup>

--- a/src/Atypical.VirtualFileSystem.Core/Atypical.VirtualFileSystem.Core.csproj
+++ b/src/Atypical.VirtualFileSystem.Core/Atypical.VirtualFileSystem.Core.csproj
@@ -17,6 +17,10 @@
     
     <!-- Development dependencies -->
     <ItemGroup>
+      <PackageReference Include="DotNet.ReproducibleBuilds" Version="2.0.5">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
       <PackageReference Include="DefaultDocumentation" Version="1.2.5">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Atypical.VirtualFileSystem.GitHub/Atypical.VirtualFileSystem.GitHub.csproj
+++ b/src/Atypical.VirtualFileSystem.GitHub/Atypical.VirtualFileSystem.GitHub.csproj
@@ -11,6 +11,14 @@
         <None Include="../../LICENSE" Pack="true" PackagePath="" />
     </ItemGroup>
 
+    <!-- Development dependencies -->
+    <ItemGroup>
+        <PackageReference Include="DotNet.ReproducibleBuilds" Version="2.0.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
     <!-- Dependencies -->
     <ItemGroup>
         <PackageReference Include="Octokit" Version="14.0.0" />


### PR DESCRIPTION
## What

The published packages carry **no debug information at all**. Checked against what is actually on nuget.org:

```
Atypical.VirtualFileSystem 0.3.0
  lib/net6.0/Atypical.VirtualFileSystem.Core.dll   embedded PDB: no
  lib/net7.0/Atypical.VirtualFileSystem.Core.dll   embedded PDB: no
  lib/net8.0/Atypical.VirtualFileSystem.Core.dll   embedded PDB: no
```

No symbol package was ever pushed either. A consumer stepping into this library lands in decompiled IL with no route back to the source.

## The fix

Add `DotNet.ReproducibleBuilds` to the two packable projects. It turns on Source Link, deterministic builds, and `DebugType=embedded` — the portable PDB then travels **inside** the assembly, so symbols and source stepping work with zero configuration on the consumer's side.

`PublishRepositoryUrl` / `EmbedUntrackedSources` go in `Directory.Build.props` alongside it.

## What this deliberately does *not* do

It does **not** add `IncludeSymbols` + `SymbolPackageFormat=snupkg`. With embedded PDBs no separate `.pdb` is ever produced, so the snupkg gets packed empty and nuget.org rejects it:

```
400 The package does not contain any symbol (.pdb) files
```

That is not hypothetical — it is what failed the first release of [PlayBlazor](https://github.com/Atypical-Consulting/PlayBlazor), and the same inert configuration is being removed from FastComponents in [FastComponents#70](https://github.com/Atypical-Consulting/FastComponents/pull/70). This repository gets the working half without the trap.

## Verified

After the change, both packages carry an embedded PDB — `MPDB` blob present in `Atypical.VirtualFileSystem.Core.dll` and `Atypical.VirtualFileSystem.GitHub.dll`.

## Noticed while here, not fixed

`Atypical.VirtualFileSystem.GitHub` has a `ProjectReference` to `Atypical.VirtualFileSystem.Providers.Abstractions`, which is not packable and is not packed by `publish-to-nuget.yml`. Should that package ever ship, it would reference an assembly no consumer can restore. It is not on nuget.org today, so nothing is broken right now — flagging it rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7hy3BpcmrBsEfqE9uGrNp